### PR TITLE
fix curl import bug in nwm_forecast.py (ln 9)

### DIFF
--- a/data/nwm_forecast.py
+++ b/data/nwm_forecast.py
@@ -6,7 +6,7 @@ import datetime as dt
 from datetime import datetime, timedelta
 from pathlib import Path
 import sh
-from gfs_download_fcns import curl
+from data.gfs_tools import curl
 
 # Adapted from python notebooks at https://www.hydroshare.org/resource/5949aec47b484e689573beeb004a2917/
 


### PR DESCRIPTION
Must've missed this bug in my last pull request... nonetheless all things nwm should work now.