### PR TITLE
Add multithreading to loading functions for GFS and NWM

### DIFF
--- a/data/gfs_tools.py
+++ b/data/gfs_tools.py
@@ -202,7 +202,7 @@ def download_gfs_threaded(dates=generate_date_strings(start_date=datetime.today(
 		if not os.path.exists(date_dir):
 			os.makedirs(date_dir)
 		for h in hours:
-			grib_fpath = os.path.join(grib_data_dir, date_dir, f'gfs.t00z.pgrb2.0p25.f{h}')
+			grib_fpath = os.path.join(date_dir, f'gfs.t00z.pgrb2.0p25.f{h}')
 			# if the grib file isn't downloaded already, then download it
 			if not os.path.exists(grib_fpath):
 				grib_url = f"https://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_0p25.pl?dir=%2Fgfs.{d}%2F00%2Fatmos&file=gfs.t00z.pgrb2.0p25.f{h}&var_CPOFP=on&var_DSWRF=on&var_PRATE=on&var_RH=on&var_TCDC=on&var_TMP=on&var_UGRD=on&var_VGRD=on&lev_2_m_above_ground=on&lev_10_m_above_ground=on&lev_surface=on&lev_entire_atmosphere=on&subregion=&toplat=47.5&leftlon=280&rightlon=293.25&bottomlat=40.25"

--- a/data/gfs_tools.py
+++ b/data/gfs_tools.py
@@ -72,7 +72,7 @@ def append_timestamp(sta_dict, loc_dict, loc_dfs):
 		# reorder & rename columns to expected convention
 		calibrate_columns(df_to_append)
 		if stationID in sta_dict:
-			sta_dict[stationID] = pd.concat([sta_dict[stationID], df_to_append])
+			sta_dict[stationID] = pd.concat([sta_dict[stationID], df_to_append]).sort_index()
 		else:
 			sta_dict[stationID] = df_to_append
 

--- a/data/nwm_forecast.py
+++ b/data/nwm_forecast.py
@@ -41,7 +41,8 @@ def GetForecastFileName(ForecastStartDate = datetime.today().strftime("%Y%m%d"),
 	
 	"""
 	BaseName = 'https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/prod/nwm.'
-	return BaseName + ForecastStartDate + '/' + ForecastMember + '_mem' + ForecastMember + '/nwm.t' + ForecastStartTimestep + 'z.medium_range.channel_rt_' + ForecastMember + '.f' + TimeStep + '.conus.nc'
+	return BaseName + ForecastStartDate + '/' + ForecastType + '_mem' + ForecastMember + '/nwm.t' + ForecastStartTimestep + 'z.medium_range.channel_rt_' + ForecastMember + '.f' + TimeStep + '.conus.nc'
+
 
 
   

--- a/lib.py
+++ b/lib.py
@@ -297,5 +297,24 @@ def multithreaded_download(download_list, num_threads=int(os.cpu_count()/2)):
 	with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
 		executor.map(download_data, urls, paths)
 
+def multithreaded_loading(load_func, file_list, num_threads=int(os.cpu_count()/2)):
+	"""
+	The idea here is to pass the function that reads datasets (xr.open_dataset, cfgrib) with multithreading, 
+	and return a dictionary with the structure {fname : dataset}
+
+	Args:
+	-- load_func (function) [required]: the function to use to open the datasets
+	-- file_list (list) [required]: list of file names to load
+	-- num_threads (int) [opt]: number of threads to use for mulithreading
+
+	Returns:
+	a dictionary where every key is a filename in file_list, and each corresponding value is the datastruct loaded for that file
+	"""
+	with concurrent.futures.ThreadPoolExecutor(max_workers=num_threads) as executor:
+		datasets = executor.map(load_func, file_list)
+		dataset_list = [d for d in datasets]
+
+	return dict(zip(file_list, dataset_list))
+
 IAMLogger.setup_logging()
 logger = logging.getLogger(get_calling_package())


### PR DESCRIPTION
Created a new function, `mulithreaded_loading()` to `lib.py` to load data with multithreading. This function was implemented in:
- `gfs_tools.py/aggregate_station_df_dict()` - loading for GFS data was already pretty quick without multithreading, but added anyway for consistency
- `nwm_forecast.py/get_data()` - loading for NWM data now takes about 20 seconds

Resolves issue #39 