### PR TITLE
Add Requirements and Google Bucket Archive Data Access

### DIFF
--- a/data/nwm_fc.py
+++ b/data/nwm_fc.py
@@ -152,7 +152,6 @@ def get_data(forecast_datetime,
 			 archive=False,
 			 return_type='dict'):
 	"""
-
 	A function to download and process NWM hydrology forecast data to return nested dictionary of pandas series fore each variable, for each location.
 	
 	Args:
@@ -164,7 +163,8 @@ def get_data(forecast_datetime,
 	-- dwnld_threads (int) [opt]: number of threads to use for downloads. Default is half of OS's available threads.
 	-- load_threads (int) [opt]: number of threads to use for reading data. Default is 2 for GFS, since file reads are already pretty fast.
 	-- forecast_cycle (str) [req]: The starting time for the forecasts. valid values are 00, 06, 12, 18
-	-- google_buckets (bool) [opt]: Flag determining wheteher or not to use google buckets for nwm download as opposed to NOMADs site.
+	-- google_buckets (bool) [opt]: Flag determining wether or not to use google buckets for nwm download as opposed to NOMADs site.
+	-- archive (bool) [opt]: Flag determining wether or not data you are grabbing is older than the last two days (relevant for NWM only)
 	-- return_type (string) [opt]: string indicating which format to return data in. Default is "dict", which will return data in a nested dict format:
 									{locationID1:{
 										var1_name:pd.Series,
@@ -173,10 +173,7 @@ def get_data(forecast_datetime,
 									locationID2:{...},
 									...
 									}
-									Alternative return type is "dataframe", which smashes all data into a single dataframe muliIndex'd by station ID, then timestamp
-	save_csv              : Flag indicating whether or not dataframes should be saved as CSV files.
-	forecast_member        : The member of the forecast model.
-	
+									Alternative return type is "dataframe", which smashes all data into a single dataframe muliIndex'd by station ID, then timestamp	
 	Returns:
 	NWM data in the format specified by return_type
 	"""

--- a/habsForecast.py
+++ b/habsForecast.py
@@ -1,6 +1,7 @@
+"""
 I think... own repo eventually... so we can track the versions
 
 Have a default config that maintains original defaults and then use new config files to show evolution
 
 but for now, this will be the code to just make it go
-
+"""

--- a/lib.py
+++ b/lib.py
@@ -334,27 +334,40 @@ def get_hour_diff(start_date, end_date):
 	hours = time_difference.total_seconds() / 3600
 	return int(hours)
 
-def generate_hours_list(num_hours, source):
+def generate_hours_list(num_hours, source, forecast_type='medium', archive=False):
 	"""
 	Creates a list of forecast hours to be downloaded
 
 	Args:
 	-- num_hours (int) [req]: how many hours of forecast data you want.
 	-- source (str) [req]: string indicating the forecast source. Valid values are 'gfs', 'nwm', and 'archive'.
+	-- forecast_type (str) [opt]: The type of NWM forecast to grab. Valid values are 'short', 'medium', or 'long'.
 
 	Returns:
 	A list of hours in the format needed for the specifed forecast source. Or None if no valid source value is passed.
 	"""
 	match source:
-		case 'archive':
-			return [f"{hour:03}" for hour in range(0, num_hours + 1, 3)]
 		case 'gfs':
 			if num_hours <= 120:
 				return [f"{hour:03}" for hour in range(0, num_hours + 1)]
 			else:
 				return [f"{hour:03}" for hour in range(0, 120)] + [f"{hour:03}" for hour in range(120, num_hours + 1, 3)]
 		case 'nwm':
-			return [f"{hour:03}" for hour in range(1, num_hours + 1)]
+			if forecast_type=='short' or forecast_type=='medium':
+				return [f"{hour:03}" for hour in range(1, num_hours + 1)]
+			if forecast_type=='long':
+				return [f"{hour:03}" for hour in range(6, num_hours + 1, 6)]
+		case 'buckets':
+			if forecast_type=='short':
+				return [f"{hour:03}" for hour in range(1, num_hours + 1)]
+			if forecast_type=='medium':
+				if archive:
+					return [f"{hour:03}" for hour in range(3, num_hours + 1, 3)]
+				else: return [f"{hour:03}" for hour in range(1, num_hours + 1)]
+			if forecast_type=='long':
+				return [f"{hour:03}" for hour in range(6, num_hours + 1, 6)]
+
+
 		
 def generate_date_strings(start_date, end_date):
 	"""

--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -236,6 +236,7 @@ def getflowfiles(forecast_start, forecast_end, whichbay, root_dir, spinup_date, 
 								  locations = {"MS":"166176984",
 											   "J-S":"4587092",
 											   "Mill":"4587100"},
+								  forecast_type="medium_range_mem1",
 								  data_dir=os.path.join(root_dir, 'forecastData/'),
 								  google_buckets = True)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 cfgrib==0.9.10.4
-jupyter
 matplotlib==3.8.2
 netCDF4==1.6.5
 numpy==1.25.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,9 @@
-pegasus-wms.api
-pandas
-sh
-xarray
+cfgrib==0.9.10.4
+jupyter
+matplotlib==3.8.2
+netCDF4==1.6.5
+numpy==1.25.2
+pandas==2.0.3
+Requests==2.31.0
+sh==2.0.6
+xarray==2023.8.0


### PR DESCRIPTION
Added a `requirements.txt` doc to the repo. Now, once a virtual environment is created, a user can install all dependencies with `pip install -r requirements.txt`. Also extended the capability of `nwm_fc.get_data()` so that it can get archived data (i.e. any data that does not follow the file system that NOMADS currently uses) from google buckets. The function can now also get other forecast ranges as well, such as `"short_range"`, `"long_range_mem3"`, etc.