### PR TITLE
Enhancements for Forecast Elasticity Experiments

### DIFF
--- a/batch/data/download_data.sh
+++ b/batch/data/download_data.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+#SBATCH --partition=bluemoon
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=8G
+#SBATCH --time=6:00:00
+#SBATCH --job-name=<JOB_NAME>
+#SBATCH --output=%x_%j.out
+#SBATCH --mail-type=FAIL
+
+set -x
+
+source /users/n/b/nbeckage/miniconda3/etc/profile.d/conda.sh
+conda activate forecast
+export PYTHONPATH=~/ciroh/forecast-workflow
+
+python download_<SOURCE>_year.py

--- a/batch/data/download_gfs_year.py
+++ b/batch/data/download_gfs_year.py
@@ -1,0 +1,36 @@
+import datetime as dt
+from data.gfs_fc_thredds import download_gfs_threaded
+from lib import generate_hours_list
+import os
+
+# define year for download
+year = 2023
+# start date for data grab - note that forecast cycle info is grabbed form the 'date' object in the active for loop
+start_dt = dt.datetime(2023,6,1)
+end_dt = dt.datetime(2023,10,31)
+# number of forecast days to download - this is the amount of forecast data we want for all members
+# from forecast_start to forecast_end
+# member 7, for example, will grab 9 total days of data (1.5 for member timedelta adjustment, 7.5 from forecast_start to end)
+fc_days = 7.5
+
+# define yearly gfs dir
+year_dir = f"/netfiles/ciroh/7dayHABsHindcast/hindcastData/gfs/{year}/"
+delta = end_dt - start_dt
+
+# download gfs data for members 1-7
+for member in range(1, 8):
+	# define the timedelta for the forecast cycle adjust
+	cycle_delta = dt.timedelta(hours=6*(member-1))
+	n_hours = int(fc_days*24 + 6*(member-1))
+	# create hours list with cycle adjustment
+	hours = generate_hours_list(num_hours=n_hours, source='gfs', archive=True)
+	dates = [(start_dt - cycle_delta) + dt.timedelta(days=d) for d in range(delta.days+1)]
+	print(f"Downloading GFS data from THREDDS for year: {year}")
+	print(f"\t START DATE: {dates[0].strftime('%Y%m%d')}")
+	print(f"\t END DATE: {dates[-1].strftime('%Y%m%d')}")
+	print(f"\t FORECAST CYCLE: {dates[0].hour:02d}")
+	print(f"\t FORECAST HOURS: {n_hours}")
+	for date in dates:
+		download_dir = os.path.join(year_dir, f"gfs.{date.strftime('%Y%m%d')}/{date.hour:02d}/atmos")
+		print(download_dir)
+		download_gfs_threaded(date=date, hours=hours, gfs_data_dir=download_dir, num_threads=8)

--- a/batch/data/download_nwm_year.py
+++ b/batch/data/download_nwm_year.py
@@ -1,0 +1,35 @@
+import datetime as dt
+from data.nwm_fc import download_nwm_threaded
+from lib import generate_hours_list
+import os
+
+# define year for download
+year = 2023
+# start date for data grab - note that forecast cycle info is grabbed form the 'date' object in the active for loop
+start_dt = dt.datetime(2023,6,1)
+end_dt = dt.datetime(2023,10,31)
+# forecast type
+fc_type = "medium_range_mem"
+# days of forecast data to download (for generate_hours_list())
+fc_days = 8
+# define yearly gfs dir
+year_dir = f"/netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/{year}/"
+delta = end_dt - start_dt
+
+# download nwm data for members 1-7
+for member in range(1, 8):
+	# hours list will be the same for NWM, regardless of member
+	hours = generate_hours_list(num_hours=(24*fc_days), source='nwm', forecast_type='medium')
+	dates = [(start_dt + dt.timedelta(days=d)) for d in range(delta.days+1)]
+	print(f"Downloading NWM {fc_type}{member} for year: {year}")
+	print(f"\t START DATE: {dates[0].strftime('%Y%m%d')}")
+	print(f"\t END DATE: {dates[-1].strftime('%Y%m%d')}")
+	print(f"\t FORECAST CYCLE: {dates[0].hour:02d}")
+	print(f"\t FORECAST HOURS: {24*fc_days}")
+	for date in dates:
+		forecast_cycle = f"{date.hour:02d}"
+		forecast_type = fc_type.split('_')[0]
+		netcdf_template = f"nwm.t{forecast_cycle}z.{forecast_type}_range.channel_rt_{member}"
+		download_dir = os.path.join(year_dir, f"nwm.{date.strftime('%Y%m%d')}/{fc_type}{member}")
+		print(download_dir)
+		download_nwm_threaded(date=date, hours=hours, nwm_data_dir=download_dir, num_threads=8, fname_template=netcdf_template, use_google_bucket=True)

--- a/batch/experiment_configTEMPLATE.json
+++ b/batch/experiment_configTEMPLATE.json
@@ -1,0 +1,13 @@
+{
+	"scenario":"<experiment_scenario>",
+	"job_name_prefix": "<scenario_job_prefix>",
+	"start_year":"<start_year>",
+	"end_year":"<end_year>",
+	"start_date":"<start_date>",
+	"end_date":"<end_date>",
+	"weather_dataset_observed" : "NOAA_LCD+FEMC_CR",
+	"weather_dataset_forecast" : "NOAA_GFS",
+	"hydrology_dataset_observed" : "USGS_IV",
+	"hydrology_dataset_forecast" : "NOAA_NWM_PROD",
+	"nwm_forecast_member" : "<nwm_forecast_member>"
+}

--- a/batch/launchExperiment.py
+++ b/batch/launchExperiment.py
@@ -1,0 +1,78 @@
+import json
+import os
+import subprocess
+import datetime as dt
+import time
+from string import Template
+import sys
+
+'''
+Script to Launch Model Runs for a given hindcast scenario
+'''
+# directory in ehcih this .py script is located
+orig = os.getcwd()
+
+# read in the experiment-spoecific config file from the command line
+experiment_conf_file = sys.argv[1]
+
+# read in the experiment-specific config file
+with open(experiment_conf_file) as experiment_config:
+	experiment_launch_params = json.load(experiment_config)
+
+# load in the default run config file
+with open("/gpfs1/home/n/b/nbeckage/ciroh/forecast-workflow/default_settings.json") as default_json_file:
+	config = json.load(default_json_file)
+
+# load in the default job script template
+with open('/netfiles/ciroh/7dayHABsHindcast/submitTEMPLATE.sh') as f:
+	src = Template(f.read())
+
+root_dir = '/netfiles/ciroh/7dayHABsHindcast/'
+scenario_dir = os.path.join(root_dir, f"{experiment_launch_params['scenario']}/")
+
+years = list(reversed([str(y) for y in range(int(experiment_launch_params['end_year']), int(experiment_launch_params['start_year'])+1)]))
+
+for year in years:
+	start_dt = dt.datetime.strptime(year+experiment_launch_params['start_date'], '%Y%m%d')
+	end_dt = dt.datetime.strptime(year+experiment_launch_params['end_date'], '%Y%m%d')
+	delta = end_dt - start_dt
+	scenario_dir_year = os.path.join(scenario_dir, f'{year}/')
+	dates = [start_dt + dt.timedelta(days=d) for d in range(delta.days+1)]
+	for date in dates:
+		scenario_dir_date = os.path.join(scenario_dir_year,date.strftime('%Y%m%d'))
+		# if the run exists, skip it
+		if os.path.exists(scenario_dir_date):
+			continue
+		os.makedirs(scenario_dir_date)
+		os.chdir(scenario_dir_date)
+
+		config['spinup_date'] = dt.datetime(date.year, 1, 1).strftime('%Y%m%d')
+		config['forecast_start'] = date.strftime('%Y%m%d')
+		config['forecast_end'] = (date + dt.timedelta(days=7)).strftime('%Y%m%d')
+		config['root_dir'] = root_dir
+		config['weather_dataset_observed'] = experiment_launch_params['weather_dataset_observed']
+		config['weather_dataset_forecast'] = experiment_launch_params['weather_dataset_forecast']
+		config['hydrology_dataset_observed'] = experiment_launch_params['hydrology_dataset_observed']
+		config['hydrology_dataset_forecast'] = experiment_launch_params['hydrology_dataset_forecast']
+		config['nwm_forecast_member'] = experiment_launch_params['nwm_forecast_member']
+
+		# wrtie the run-specific config file
+		with open('configuration.json', 'w') as config_file:
+			json.dump(config, config_file)
+			config_file.write('\n')
+
+		# define the job params for the run
+		job_params = {'job_name':f'{experiment_launch_params["job_name_prefix"]}{date.strftime("%Y%m%d")}',
+			  		  'run_dir':scenario_dir_date}
+		job_script = src.substitute(job_params)
+
+		# write the run-specifc submit script
+		with open('submit.sh', 'w') as submit_script:
+			submit_script.write(job_script)
+
+		print(scenario_dir_date)
+		# Uncomment to submit
+		subprocess.run(['sbatch ' 'submit.sh'], shell=True)
+		# wait so as to not overwhelm the THREDDS server
+		# time.sleep(180)
+os.chdir(orig)

--- a/batch/launchExperimentTEMPLATE.sh
+++ b/batch/launchExperimentTEMPLATE.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#SBATCH --partition=bluemoon
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=8G
+#SBATCH --time=30:00:00
+#SBATCH --job-name=<YOUR_JOB_NAME>
+#SBATCH --output=%x_%j.out
+#SBATCH --mail-type=FAIL
+
+source /users/n/b/nbeckage/miniconda3/etc/profile.d/conda.sh
+conda activate forecast
+
+# change to whatever directory you want to put your scenario runs in
+# currently VACC speciifc
+cd /netfiles/ciroh/7dayHABsHindcast/<SCENARIO_DIR>/
+
+# note that you must have an experiment-specific configuration file in your scenario directory
+python ../launchExperiment.py experiment_config.json
+

--- a/batch/rm_bad_runsTEMPLATE.sh
+++ b/batch/rm_bad_runsTEMPLATE.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Define the parent directory - the folder in your current working directory you want to comb through
+# usually a year's worth of model runs: 2023/, 2022, etc
+parent_dir="year"
+# Define job prefix - defined in the scenario's experiment_config.json
+job_pref="QM#_"
+# Define error message - last line of your model run's out file that identifies failed runs
+# note that carrot only looks for string at the beginning of the line (regex)
+error="Exception: AEM3D failure."
+
+# Loop through each subdirectory
+for dir in "$parent_dir"/*; do
+    if [ -d "$dir" ]; then
+        # Check if the subdirectory contains the specified file
+        if [ -e "$dir"/"$job_pref"* ]; then
+            # Get the last line of the file and check if they contain the specified text
+            if tail -n 1 "$dir"/"$job_pref"* | grep -q "$error"; then
+                # If the text is found, remove the entire directory
+                echo "Removing directory: $dir"
+				tail -n 1 "$dir"/"$job_pref"*
+				# CAUTION - uncomment to actually delete entire run dir - THIS CANNOT BE UNDONE!
+                # rm -rf "$dir"
+            fi
+        fi
+    fi
+done

--- a/batch/submitTEMPLATE.sh
+++ b/batch/submitTEMPLATE.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+#SBATCH --partition=bluemoon
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --mem=8G
+#SBATCH --time=18:00:00
+#SBATCH --job-name=$job_name
+#SBATCH --output=%x_%j.out
+#SBATCH --mail-type=FAIL
+
+set -x
+
+source /users/n/b/nbeckage/miniconda3/etc/profile.d/conda.sh
+conda activate forecast
+export PYTHONPATH=~/ciroh/forecast-workflow
+
+cd $run_dir
+
+python -m models.aem3d.AEM3D_prep_FEE_worker --conf configuration.json
+python -m models.aem3d.AEM3D_worker

--- a/data/gfs_fc_thredds.py
+++ b/data/gfs_fc_thredds.py
@@ -70,7 +70,7 @@ def download_gfs_threaded(date,
 	# if download_list isn't empty:
 	if download_list:
 		# The true max hits/min allowed before getting blocked by NOMADS is 120/min, but they've requested users stick to 50/min
-		max_hits_per_min = 50
+		max_hits_per_min = 65
 		# break our list into chunks of 50 elements
 		download_chunks = list(more_itertools.chunked(download_list, max_hits_per_min))
 		for i, dwnld_chunk in enumerate(download_chunks):

--- a/default_settings.json
+++ b/default_settings.json
@@ -8,7 +8,9 @@
 	"weather_dataset_forecast" : "NOAA_GFS",
 	"hydrology_dataset_observed" : "USGS_IV",
 	"hydrology_dataset_forecast" : "NOAA_NWM_PROD",
+	"nwm_forecast_member" : "medium_range_mem1",
 	"csv" : false,
-	"root_dir" : "/data/",
-	"new_dirs": true
+	"root_dir" : "/netfiles/ciroh/7dayHABsHindcast/",
+	"aem3d_input_dir" : "/netfiles/ciroh/models/aem3d/current/AEM3D-inputs",
+	"aem3d_command_path" : "/gpfs1/home/n/b/nbeckage/ciroh/aem3d-1.1.2-535/aem3d_openmp.exe"
 }

--- a/lib.py
+++ b/lib.py
@@ -260,20 +260,6 @@ def check_frame(frame):
 		return True
 	return False
 
-# old get_calling_package() - doesn't work
-"""
-def get_calling_package():
-	calling_package = None
-
-	current_frame = list(sys._current_frames().values())[0]
-	while(check_frame(current_frame)):
-		current_frame = current_frame.f_back
-
-	calling_package = current_frame.f_globals['__package__']
-	# print(f'Calling Package: {calling_package}')
-	return calling_package
-"""
-
 # New get_calling_package()
 def get_calling_package():
 	"""

--- a/lib.py
+++ b/lib.py
@@ -443,8 +443,14 @@ def multithreaded_loading(load_func, file_list, n_threads):
 	with concurrent.futures.ThreadPoolExecutor(max_workers=n_threads) as executor:
 		datasets = executor.map(load_func, file_list)
 	# returns datasets in the order in which they were submited; order of file_list will be preserved
-	dataset_list = [d for d in datasets]
-
+	# dataset_list = [d for d in datasets]
+	dataset_list = []
+	# try to capture errors from failed file loads, but continue on since a missing file or too won't hurt AEM3D much
+	for d in datasets:
+		try:
+			dataset_list.append(d)
+		except Exception as e:
+			print(e)
 	return dict(zip(file_list, dataset_list))
 
 IAMLogger.setup_logging()

--- a/models/aem3d/AEM3D_prep_FEE_IAM.py
+++ b/models/aem3d/AEM3D_prep_FEE_IAM.py
@@ -15,6 +15,7 @@
 #
 #  Control File
 
+import copy
 from lib import *
 from data import (femc_ob,
 				  nwm_fc, 
@@ -415,19 +416,20 @@ def genclimatefiles(whichbay, settings):
 	if settings['weather_dataset_observed'] == 'NOAA_LCD+FEMC_CR':
 		observedClimateBTV = lcd_ob.get_data(start_date = settings['spinup_date'] - dt.timedelta(days=1),
 										end_date = settings['forecast_start'],
-										locations = {"401":"72617014742",
-													"402":"72617014742",
-													"403":"72617014742"})
+										locations = {"401":"72617014742"})
 		
 		## TODOFEE: Need to move all the nudging and zone assignments to here!!!
 		
 		observedClimateCR = femc_ob.get_data(start_date = settings['spinup_date'] - dt.timedelta(days=1),
 										end_date = settings['forecast_start'],
-										locations = {'401':'ColReefQAQC',
-													 '402':'ColReefQAQC',
-													 '403':'ColReefQAQC'})
+										locations = {'401':'ColReefQAQC'})
 		
 		###### FEMC+LCD DATA ADJUSTMENTS HERE ######
+		# make additional location dictionaries here rather than call for the same location multiple times in get_data()'s
+		for key in ['402', '403']:
+			observedClimateBTV[key] = copy.deepcopy(observedClimateBTV['401'])
+			observedClimateCR[key] = copy.deepcopy(observedClimateCR['401'])
+
 		# cool new way to combine dictionaries (python >= 3.9)for zone, ds in climateObsCR.items():
 		# Both FEMC and LCD data grabbers now need mathing location keys to work since they are being combine
 		for zone in observedClimateCR.keys():
@@ -442,19 +444,21 @@ def genclimatefiles(whichbay, settings):
 	if settings['weather_dataset_forecast'] == 'NOAA_LCD+FEMC_CR':
 		forecastClimateBTV = lcd_ob.get_data(start_date = settings['forecast_start'],
 								end_date = settings['forecast_end'] + dt.timedelta(days=1),
-								locations = {"401":"72617014742",
-											"402":"72617014742",
-											"403":"72617014742"})
+								locations = {"401":"72617014742"})
 		
 		## TODOFEE: Need to move all the nudging and zone assignments to here!!!
 		
 		forecastClimateCR = femc_ob.get_data(start_date = settings['forecast_start'],
 										end_date = settings['forecast_end'] + dt.timedelta(days=1),
-										locations = {'401':'ColReefQAQC',
-													 '402':'ColReefQAQC',
-													 '403':'ColReefQAQC'})
+										locations = {'401':'ColReefQAQC'})
+		
+		# copy data from 401 for 402, 403. Mzke sure it's a deep copy, not memeory reference
 		
 		###### FEMC+LCD DATA ADJUSTMENTS HERE ######
+			# make additional location dictionaries here rather than call for the same location multiple times in get_data()'s
+		for key in ['402', '403']:
+			forecastClimateBTV[key] = copy.deepcopy(forecastClimateBTV['401'])
+			forecastClimateCR[key] = copy.deepcopy(forecastClimateCR['401'])
 		# cool new way to combine dictionaries (python >= 3.9)for zone, ds in climateObsCR.items():
 		# Both FEMC and LCD data grabbers now need mathing location keys to work since they are being combine
 		for zone in forecastClimateCR.keys():

--- a/models/aem3d/AEM3D_prep_FEE_IAM.py
+++ b/models/aem3d/AEM3D_prep_FEE_IAM.py
@@ -1,0 +1,1075 @@
+#  Creates the AEM3D Lake Model Input Contents
+#
+#  Time Series
+#       Flow from RHESSys or SWAT
+#       Weather from WRF
+#         Net Longwave Radiation
+#         Precipitation
+#         Temperature
+#		  Wind
+#         Humidity
+#       Lake Level (flow and temp related)
+#       Salinity
+#       Tracers
+#       Call waterquality.py to wq files
+#
+#  Control File
+
+from lib import *
+from data import (femc_ob,
+				  nwm_fc, 
+				  usgs_ob,
+				  gfs_fc_thredds,
+				  lcd_ob
+)
+
+from .waterquality import *
+
+import pandas as pd
+import matplotlib.pyplot as plt
+import numpy as np
+import glob
+import os
+import datetime as dt
+
+AEM3D_DEL_T = 300
+
+# initialize empty dict to store information for each subplot to be made
+SUBPLOT_PACKAGES = {}
+
+# set up 2x5 figure to add subplots to
+FIG, AXES = plt.subplots(nrows=2, ncols=5, figsize=(20, 10), sharex=True, layout='constrained')
+FIG.supxlabel('Datetime')
+# fig.suptitle()
+# Rotate x-axis tick labels by 45 degrees
+for i in range(0,5):
+	for label in AXES[1,i].get_xticklabels():
+		label.set_rotation(45)
+FIG.delaxes(AXES[0,4])
+
+
+def add_plot(labelled_data, ylabel, title, fc_start, row, col, axis):
+	ax = axis[row,col]
+	# Plot data for location 1
+	for lab, data in labelled_data.items():
+		time_sliced_data = data[data.index <= pd.Timestamp(fc_start + dt.timedelta(days=7))]
+		time_sliced_data = time_sliced_data[time_sliced_data.index > pd.Timestamp(fc_start - dt.timedelta(days=14))]
+		ax.plot(time_sliced_data.index, time_sliced_data, label=lab)
+
+	# Add labels and title
+	# ax.set_xlabel('Datetime')
+	ax.set_ylabel(ylabel)
+	ax.set_title(title)
+	ax.grid(True)
+	ax.legend()
+
+	# Adding vert line at point where data goes from USGS to NWM
+	ax.axvline(x=pd.Timestamp(fc_start), color='r', linestyle='--')
+
+def make_figure(plot_package):
+	for kwargs in plot_package.values():
+		add_plot(**kwargs)
+
+def print_df(df):
+	logger.info('\n'
+				f'{df}\n'
+				f'column_dtypes:\n{df.dtypes}\n'
+				f'index_dtype: {df.index.dtype}\n'
+				)
+
+def colsToHeader(columns):
+	return_string = ''
+	for col in columns:
+		return_string += ' ' + str(col)
+	return return_string
+
+def remove_nas(series):
+	# logger.info('Size with nas')
+	# logger.info(len(series))
+	# new_series = series[~series.isna()]
+	# logger.info('Size without nas')
+	# logger.info(len(new_series))    
+	# return new_series
+	return series[~series.isna()]
+
+def datetimeToOrdinal(date):
+
+	dayofyear = date.strftime('%j')
+
+	# Left pad dayofyear to length 3 by zeros
+	yearday = str(date.year) + dayofyear.zfill(3)
+
+	totseconds = date.hour * 3600 + \
+				 date.minute * 60 + \
+				 date.second
+	fracsec = totseconds / dt.timedelta(days=1).total_seconds()  #Fraction of the day's seconds
+
+	ordinaldate = yearday + str(fracsec)[1:6].ljust(5,'0')  # add the percentage seconds since noon
+	return ordinaldate
+
+def seriesIndexToOrdinalDate(series):
+	# Now, using datetimeToOrdinal()
+	ordinaldate = series.index.to_series().apply(datetimeToOrdinal)
+
+	#ordinaldate = pandasDatetimeToOrdinal(series.index)
+	#ordinaldate = pd.Series(wrfdf['ordinaldate'].array, index = wrfdf['wrftime'])
+	return pd.Series(series.array, index = ordinaldate)
+
+def ordinalnudgerow(rowtonudge, columntonudge, nudgeframe):
+	# apply a proportional nudge value that is specific to the day of year in the passed row
+	#   rowtonudge - row from a dataframe with TIME column and a value column
+	#   columntonudge - the specific column name to apply the data adjustement to
+	#   nudgeframe - dataframe with days of year and proportions (NudgeObs) to apply to the data that needs nudging
+
+	DOY = int(rowtonudge['TIME'].split('.')[0][-3:])    # pull the day of year from ordinal date
+	nudged = rowtonudge[columntonudge] * nudgeframe.loc[nudgeframe['Day of Year'] == DOY]['NudgeObs']
+	return nudged.reset_index(drop=True)
+
+def writeFile(filename, bayid, zone, varName, dataSeries):
+	with open(filename, mode='w', newline='') as output_file:
+
+		# output the header text
+		output_file.write('!-----------------------------------------------------!\n')
+		output_file.write('! Written by AEM3D_prep_FEE_IAM                           !\n')
+		output_file.write(f'! Bay ID: {bayid}                                 !\n')
+		#output_file.write('! Bay Source: ' + bs_name + '                         !\n')
+		output_file.write('!-----------------------------------------------------!\n')
+		output_file.write('1 data sets\n')
+		output_file.write('0 seconds between data\n')
+		output_file.write(f'0            {zone}\n')
+		output_file.write(f'TIME         {varName}\n')
+
+		dataSeries.to_csv(path_or_buf = output_file, float_format='%.3f', sep=' ', index=True, header=False)
+
+def writeLongwaveRadiationDownward(climate, THEBAY):
+	###########################################################################################
+	#
+	#   Longwave Radiation Downward : GLW
+	#
+
+	for zone in climate['AEMLW'].keys():
+		filename = f'LWRADIN_{zone}.dat'
+		logger.info('Generating Bay Longwave Radiation Downward File: '+filename)
+		writeFile(
+			os.path.join(THEBAY.infile_dir, filename),
+			THEBAY.bayid,
+			zone,
+			"LW_RAD_IN",
+			seriesIndexToOrdinalDate(climate['AEMLW'][zone]))
+		THEBAY.addfile(fname=filename)
+
+
+def writeCloudCover(climate, THEBAY):
+	###########################################################################################
+	#
+	#   Longwave Radiation Downward : GLW
+	#
+
+	for zone in climate['AEMLW'].keys():
+		filename = f'CLOUDS_{zone}.dat'
+		logger.info('Generating Bay Cloud Cover File: '+filename)
+		writeFile(
+			os.path.join(THEBAY.infile_dir, filename),
+			THEBAY.bayid,
+			zone,
+			"CLOUDS",
+			seriesIndexToOrdinalDate(climate['AEMLW'][zone]))
+		THEBAY.addfile(fname=filename)
+
+
+#########################################################################
+#
+#   Import Hydrology Flow - Generate Flow Files
+#
+##########################################################################
+
+
+def getflowfiles(forecast_start, forecast_end, whichbay, root_dir, spinup_date, directory_flag):
+	'''
+	getflowfiles : Get hydrology model flow file(s) for Bay Inflow
+		Most information contained in passed Bay Object
+	'''
+
+	THEBAY = whichbay
+
+	#
+	#   InLandSea has 3 *basin.daily files that provide input flow
+	#
+	logger.info('Loading Hydrology Flow Data')
+	#print (flowFiles)
+
+	#
+	#   2 years spinup and 10 years of output in the _daily file
+	#   Trim extracted data to just the year of interest
+	#   Don't use time stamps, because rhessys generates unwanted leap days
+	#   Generate 365 records for the year to match the leapless climate data
+	#
+	#records2skip = (2 + THEBAY.year - year_to_decade(THEBAY.year))*365      # skip spinup and prior years
+
+	######### TODO: Instead of from file below, get from data gathering functions
+	
+	# dict by id: 04294000 (MS), 04292810 (J-S), 04292750 (Mill)
+	# the below line is throwing an error - THEBAY.FirstDate is a str, should be datetime
+	
+	observedUSGS = usgs_ob.get_data(start_date = spinup_date - dt.timedelta(days=1),
+								 	end_date = forecast_start,
+									locations = {"MS":'04294000',
+			   									 "J-S":'04292810',
+			   									 "Mill":'04292750'})
+
+	forecastNWM = nwm_fc.get_data(forecast_datetime = forecast_start,
+								  end_datetime = forecast_end + dt.timedelta(days=1),
+								  locations = {"MS":"166176984",
+											   "J-S":"4587092",
+											   "Mill":"4587100"},
+								  forecast_type="medium_range_mem1",
+								  data_dir=os.path.join(root_dir, 'hindcastData/'),
+								  load_threads=1,
+								  google_buckets = True)
+
+
+	# Convert USGS streamflow from cubic ft / s to cubic m / s
+	observedUSGS['MS']['streamflow'] = observedUSGS['MS']['streamflow'] * 0.0283168
+	observedUSGS['Mill']['streamflow'] = observedUSGS['Mill']['streamflow'] * 0.0283168
+	observedUSGS['J-S']['streamflow'] = observedUSGS['J-S']['streamflow'] * 0.0283168
+
+	# Need to adjust for column names and convert from ft / s to m / s
+	flowdf = pd.concat([observedUSGS['MS']['streamflow'], forecastNWM['MS']['streamflow']]).rename_axis('time').astype('float').to_frame()
+	mlflow = pd.concat([observedUSGS['Mill']['streamflow'], forecastNWM['Mill']['streamflow']]).rename_axis('time').astype('float').to_frame()
+	jsflow = pd.concat([observedUSGS['J-S']['streamflow'], forecastNWM['J-S']['streamflow']]).rename_axis('time').astype('float').to_frame()
+
+	# these df's may not be the same length, there may be missing data from USGS gauges
+	logger.info(flowdf)
+	logger.info(mlflow)
+	logger.info(jsflow)
+
+	# sometimes there are negative sensor readings, let's get rid of those if they're there
+	flowdf =  flowdf[flowdf['streamflow'] >= 0].reindex(flowdf.index, method='nearest')
+	mlflow =  mlflow[mlflow['streamflow'] >= 0].reindex(mlflow.index, method='nearest')
+	jsflow =  jsflow[jsflow['streamflow'] >= 0].reindex(jsflow.index, method='nearest')
+
+	flow_data = {'Missisquoi':flowdf['streamflow'],
+				 'Mill':mlflow['streamflow'],
+				 'Jewett-Stevens':jsflow['streamflow']}
+
+	global SUBPLOT_PACKAGES
+	global AXES
+	SUBPLOT_PACKAGES['streamflow'] = {'labelled_data':flow_data,
+								   	  'ylabel':'Streamflow (m/s^3)',
+									  'title':'USGS vs. NWM Streamflow',
+									  'fc_start':forecast_start,
+									  'row':0,
+									  'col':0,
+									  'axis':AXES}
+
+
+	flowdf.columns = ['msflow']
+	## Have to merge the other two because USGS sometimes doesn't return all dates for all gauges
+	jsflow.columns = ['jsflow']
+	flowdf = pd.merge(flowdf, jsflow, on='time', how='inner')
+	mlflow.columns = ['mlflow']
+	flowdf = pd.merge(flowdf, mlflow, on='time', how='inner')
+
+	flowdf['ordinaldate'] = flowdf.index.to_series().apply(datetimeToOrdinal)
+
+	logger.info(flowdf)
+
+	# Store flow series in bay object for later
+	THEBAY.flowdf = flowdf[['ordinaldate', 'msflow', 'mlflow', 'jsflow']].copy()
+
+	logger.info('Daily Flow Data Scaled')
+	# Scale Additional Inflows from Predicted Inflow
+	#       sourcelist has list of source IDs
+	#       sourcemap defines the source name and proportion of hydromodel output flow
+	for baysource in THEBAY.sourcelist :
+		logger.info('Generating Bay Source File for Id: '+baysource)
+		bs_prop = THEBAY.sourcemap[baysource]['prop']           # proportion of input file for this source
+		wshed = THEBAY.sourcemap[baysource]['wshed']            # get column name of watershed flow source for this stream
+		flowdf[baysource] = flowdf[wshed] * bs_prop             # scale source from hydromodel flow (some are split)
+		bs_name = THEBAY.sourcemap[baysource]['name']
+		filename = bs_name + '_Flow.dat'
+		logger.info('Bay Source File to Generate: '+filename)
+		# Write Inflow File
+		# open the file in output directory
+		pathedfile = os.path.join(THEBAY.infile_dir, filename)
+		with open(pathedfile, mode='w', newline='') as output_file:
+			THEBAY.addfile(fname=filename)    # remember generated file names
+			# output the header text
+			output_file.write('!-----------------------------------------------------!\n')
+			output_file.write('! Written by AEM3D_prep_FEE_IAM                           !\n')
+			output_file.write('! Bay ID: '+ THEBAY.bayid + '                         !\n')
+			output_file.write('! Bay Source: ' + bs_name + '                         !\n')
+			output_file.write('!-----------------------------------------------------!\n')
+			output_file.write('1 data sets\n')
+			output_file.write('0 seconds between data\n')
+			output_file.write('0    ' + baysource + '\n')
+			output_file.write('TIME      INFLOW\n')
+			# output the ordinal date and flow value time dataframe columns
+			flowdf.to_csv(path_or_buf = output_file, columns= ['ordinaldate', baysource], float_format='%.3f',
+			sep=' ', index=False, header=False)
+
+##
+#       End of Flow Data Import
+#
+##
+
+#########################################################################
+#
+#   All Things Meteorology Related Handled Herein
+#
+##########################################################################
+
+
+def genclimatefiles(forecast_start, forecast_end, whichbay, gfs_csv, root_dir, spinup_date, directory_flag):
+
+	global SCENARIO
+
+	THEBAY = whichbay   # passed object defining bay characteristics
+	year=THEBAY.year   # starting year pulled from IAMBAY class object (lib.py)
+
+	#
+	#   Read WRF climate data
+	#
+	logger.info('Processing Meterological Data')
+
+	climateObsBTV = lcd_ob.get_data(start_date = spinup_date - dt.timedelta(days=1),
+								 	end_date = forecast_start,
+									locations = {"BTV":"72617014742"})
+	
+	climateObsCR = femc_ob.get_data(start_date = spinup_date - dt.timedelta(days=1),
+									end_date = forecast_start,
+									locations = {'CR':'ColReefQAQC'})#.rename_axis('time')
+	
+	# if flag is true, use new (post-update) dir struture. This is the default behavior
+	if directory_flag:
+		# new dir structure
+		gfs_download_dir = f'forecastData/gfs/gfs.{forecast_start.strftime("%Y%m%d")}'
+	else:
+		# old dir structure
+		gfs_download_dir = f'forecastData/gfs/raw_fc_data/gfs.{forecast_start.strftime("%Y%m%d")}'
+
+	############## Use this bit to load forecast climate from .csvs previously created above
+	if gfs_csv:
+		logger.info("Loading GFS From CSVs")
+		climateForecast = {}
+		for zone in ['401', '402', '403']:
+			climateForecast[zone] = pd.read_csv(
+						os.path.join(root_dir, gfs_download_dir, f'gfs{zone}.csv'),
+						index_col='time',
+						parse_dates=True)
+	##############
+	else:
+	############## Use this bit to load forecast climate from original GRIB files and create .csvs for quick loading later
+
+		logger.info(f"Begin GFS get_data()")
+		climateForecast = gfs_fc_thredds.get_data(forecast_datetime = forecast_start,
+												  end_datetime = forecast_end + dt.timedelta(days=1),
+												  locations = {'401': (45.00, -73.25),
+					 										   '402': (44.75, -73.25),
+					 										   '403': (44.75, -73.25)},
+												  data_dir = os.path.join(root_dir, 'hindcastData/'),
+												  load_threads = 1)
+	##############
+
+	logger.info('BTV Data')
+	logger.info(climateObsBTV['BTV'])
+	logger.info('Colchester Data')
+	logger.info(climateObsCR['CR'])
+	logger.info('GFS Data (Zone 401)')
+	logger.info(climateForecast['401'])
+
+	#
+	#   Generate the Ordinal Date (yeardayofyear.percentseconds)
+	#
+
+	# S.E.T. - 20240206 - Adjust Colchester Reef Observed temp by month for the Missisquoi Bay Zone (401)
+	# the adjustment, by month, to apply to CR data for use in MissBay
+	tempadjust = {
+    	1 : -2.6,
+    	2 : -2.4,
+    	3 : -0.7,
+    	4 : 0.8,
+    	5 : 1.3,
+    	6 : 0.8,
+    	7 : -0.4,
+    	8 : -0.8,
+    	9 : -1.0,
+    	10 : -1.2,
+    	11 : -1.6,
+    	12 : -2.4 }
+
+	adjustedCRtemp = pd.Series()
+	for row in range(climateObsCR['CR']['T2'].shape[0]):
+		adjustedCRtemp[row] = climateObsCR['CR']['T2'].iloc[row] + tempadjust[climateObsCR['CR']['T2'].index[row].month]
+	adjustedCRtemp = adjustedCRtemp.set_axis(climateObsCR['CR']['T2'].index)
+
+
+	air_temp = {"401": pd.concat([remove_nas(adjustedCRtemp),climateForecast['401']['T2']-273.15]),
+				"402": pd.concat([remove_nas(climateObsCR['CR']['T2']),climateForecast['402']['T2']-273.15]),
+				"403": pd.concat([remove_nas(climateObsCR['CR']['T2']),climateForecast['403']['T2']-273.15])
+	 }
+
+	global SUBPLOT_PACKAGES
+	global AXES
+	SUBPLOT_PACKAGES['air temp'] = {'labelled_data':air_temp,
+								   	'ylabel':'Air Temp at 2m (C)',
+									'title':'Observed vs. Forecasted Air Temperature',
+									'fc_start':forecast_start,
+									'row':0,
+									'col':1,
+									'axis':AXES}
+	
+	logger.info(print_df(air_temp['401']))
+
+	# Use air temp at zone 403 (ILS)
+	wtr_temp = air_temp['403'].rolling(window=96,min_periods=1).mean() # moving average over 4 days
+
+	wtr_temp.loc[wtr_temp<0] = 0  # no subfreezing water
+	wtr_temp = wtr_temp + 0.75    # 0.75 correction based on WQS Docs 2021.05.27
+
+	# Store temp series in bay object for later use in wq calcs
+	# THEBAY.tempdf = wrfdf[['ordinaldate', 'wtr_temp']].copy()
+	THEBAY.tempdf = pd.DataFrame({'ordinaldate' : wtr_temp.index.to_series().apply(datetimeToOrdinal), 'wtr_temp' : wtr_temp.array})
+
+
+	#
+	#       Write the temperature file for each source of the bay
+	#
+	for baysource in THEBAY.sourcelist :
+
+		bs_name = THEBAY.sourcemap[baysource]['name']
+		filename = bs_name + '_Temp.dat'
+		logger.info('Generating Bay Source Temperature File: '+filename)
+
+		# Write Temp File
+		# open the file in output directory
+		pathedfile = os.path.join(THEBAY.infile_dir, filename)
+		with open(pathedfile, mode='w', newline='') as output_file:
+
+			THEBAY.addfile(fname=filename)        # remember generated bay files
+
+			# output the header text
+			output_file.write('!-----------------------------------------------------!\n')
+			output_file.write('! Written by AEM3D_prep_FEE_IAM                           !\n')
+			output_file.write('! Bay ID: '+ THEBAY.bayid + '                            !\n')
+			output_file.write('! Bay Source: ' + bs_name + '                         !\n')
+			output_file.write('!-----------------------------------------------------!\n')
+			output_file.write('1 data sets\n')
+			output_file.write('0 seconds between data\n')
+			output_file.write('0    '+baysource+'\n')
+			output_file.write('TIME      WTR_TEMP\n')
+
+			# output the ordinal date and temp dataframe columns
+			seriesIndexToOrdinalDate(wtr_temp).to_csv(path_or_buf = output_file, float_format='%.3f',
+			sep=' ', index=True, header=False)
+
+	#
+	#   end water temp file
+
+	######################################################################################
+	#
+	#   Rain (WRF RAIN) and Snow
+	#
+	bay_rain = dict()
+	bay_snow = dict()
+
+	### TODO: Remove hardcoded single RAIN zone
+	for zone in ['403']:
+		
+		# ['RAIN'] for BTV to get to a series
+		# AEM3D wants meters/day
+		# BTV is in inches/hr so thats * 24 to get hr -> day and * 0.0254 to convert inches to meters
+		#   for a total of 0.6096
+		#   LCD Ref: https://www.ncei.noaa.gov/pub/data/cdo/documentation/LCD_documentation.pdf
+		# GFS is in kg/m^2/s. kg/m^2 is mm, so really mm/s. To convert, * 86400 to get sec -> day,
+		#   and / 1000 to get mm to m, so, in all, * 86.4
+		#   GFS Ref: https://www.nco.ncep.noaa.gov/pmb/products/gfs/gfs.t00z.pgrb2.0p25.f003.shtml
+		bay_rain[zone] = pd.concat([climateObsBTV['BTV']['RAIN'] * 0.6096, climateForecast[zone]['RAIN'] * 86.4])
+
+		print(air_temp[zone])
+		TEMP = air_temp[zone].reindex(bay_rain[zone].index, method='nearest')
+
+		logger.info('TEMP after reindex')
+		logger.info(print_df(TEMP))
+
+		# Original Try: Use https://www.ncdc.noaa.gov/sites/default/files/attachments/Estimating_the_Water_Equivalent_of_Snow.pdf
+		#   and fit a quadratic regression through it
+		#   SNOW = e^(2.3129520 + -0.0962303*TEMP(C) + -0.0009388*TEMP(C)*TEMP(C)) * PRECIP
+		#   This was too much though, so looking at the calibration input, divide in half
+		#   to get closer to calibration input
+		#snowcoeff = np.exp(2.3129520 - 0.0962303*TEMP - 0.0009388*TEMP*TEMP)/2.0
+		
+		# Take Two: Using GHCN data from BTV (Burlington Airport)
+		# See Pat's rainToSnow.R
+		# Calculate ratio using SNOW/PRCP, only take 1991 - present and days where SNOW and PRCP > 0
+		# Tried using TMAX, but TAVG ((TMAX + TMIN)/2) got a curve closer to NASA table and makes more sense
+		snowcoeff = np.exp(2.1413626 - 0.1921400*TEMP - 0.0079924*TEMP*TEMP)
+
+		logger.info('bay_rain')
+		logger.info(print_df(bay_rain[zone]))
+		
+		# Also a series, name = T2
+		logger.info('snowcoeff')
+		logger.info(print_df(snowcoeff))
+
+		#####################
+
+		# Merge bay_rain and snowcoeff by time stamps so we know we have times for both
+		snowcalc_df = pd.merge(bay_rain[zone], snowcoeff, on='time', how='inner')
+		logger.info('snowcalc_df')
+		logger.info(print_df(snowcalc_df))
+		bay_snow[zone] = snowcalc_df['RAIN'] * snowcalc_df['T2']
+		
+		# If too warm, no snow - Use -2.0 C to get mean snowfall for 2017-2020 close to calibration data
+		#  NOAA table above uses 34 F (1.1 C)
+		bay_snow[zone].loc[TEMP > -2.0] = 0.0
+		# In the WQS AEM3D calibration SNOW / RAIN data, RAIN looks like snow equivalent
+		#   and SNOW is depth of snow, so we should have values for both when it snows
+		# bay_rain[zone].loc[bay_snow[zone] > 0.0] = 0.0
+
+		logger.info('bay_snow before write')
+		logger.info(print_df(bay_snow[zone]))        
+		logger.info('bay_rain before write')
+		logger.info(print_df(bay_rain[zone])) 
+
+	SUBPLOT_PACKAGES['bay rain'] = {'labelled_data':bay_rain,
+									'ylabel':'Rainfall (m/day)',
+									'title':'Rainfall for Inland Sea',
+									'fc_start':forecast_start,
+									'row':0,
+									'col':2,
+									'axis':AXES}
+	
+	SUBPLOT_PACKAGES['bay snow'] = {'labelled_data':bay_snow,
+									'ylabel':'Snow Fall (m/day)',
+									'title':'Snow Fall for Inland Sea',
+									'fc_start':forecast_start,
+									'row':0,
+									'col':3,
+									'axis':AXES}
+
+	#
+	# Write Precip Files for Bay
+	#
+	for zone in bay_rain.keys():
+		#################################
+		# Hardcode zone to 0 for now... only one precip station
+		filename = f'PRECIP_0.dat'
+		logger.info('Generating Bay Precipitation File: '+filename)
+
+		with open(os.path.join(THEBAY.infile_dir, filename), mode='w', newline='') as output_file:
+
+			THEBAY.addfile(fname=filename)        # remember generated bay files
+
+			# output the header text
+			output_file.write('!-----------------------------------------------------!\n')
+			output_file.write('! Written by AEM3D_prep_FEE_IAM                           !\n')
+			output_file.write('! Bay ID: '+ THEBAY.bayid + '                         !\n')
+			#output_file.write('! Bay Source: ' + bs_name + '                        !\n')
+			output_file.write('!-----------------------------------------------------!\n')
+			output_file.write('2 data sets\n')
+			output_file.write('0 seconds between data\n')
+			output_file.write('0    0    0\n')
+			output_file.write('TIME      RAIN     SNOW\n')
+
+			# output the ordinal date and flow value time dataframe columns
+			pd.concat([
+					seriesIndexToOrdinalDate(bay_rain[zone]),
+					seriesIndexToOrdinalDate(bay_snow[zone])],
+					axis=1).to_csv(
+					path_or_buf = output_file,
+					float_format='%.3f',
+					sep=' ',
+					index=True, header=False)
+
+	#   end precip file
+
+
+	###########################################################################################
+	#
+	#   Longwave Radiation Measure : CLOUDS, LW_RAD_IN, or LW_RAD_NET
+	#
+
+	# Use Cloud Cover
+	cloud_plot_data = {}
+	for zone in climateForecast.keys():
+		filename = f'CLOUDS_{zone}.dat'
+		logger.info('Generating Bay Cloud Cover File: '+filename)
+
+		# Divide GFS TCDC by 100 to get true percentage
+		full_cloud_series = pd.concat([climateObsBTV['BTV']['TCDC'],climateForecast[zone]['TCDC']/100.0])
+		cloud_plot_data[zone] = full_cloud_series
+
+		cloud_series = seriesIndexToOrdinalDate(full_cloud_series)
+		logger.info(f'TCDC for zone {zone}') 
+		logger.info(print_df(cloud_series))
+
+		writeFile(
+			os.path.join(THEBAY.infile_dir, filename),
+			THEBAY.bayid,
+			zone,
+			"CLOUDS",
+			cloud_series
+		)
+		THEBAY.addfile(fname=filename)
+
+	SUBPLOT_PACKAGES['cloud cover'] = {'labelled_data':cloud_plot_data,
+										'ylabel':'% Total Cloud Cover',
+										'title':'Cloud Cover',
+										'fc_start':forecast_start,
+										'row':1,
+										'col':0,
+										'axis':AXES}
+
+	###########################################################################################
+	#
+	#   Wind Speed and Direction
+	#           U10 and V10 variables converted to Earth compass direction and speed
+	#
+
+	windspd = dict()
+	winddir = dict()
+	for zone in climateForecast.keys():
+		# a bit of vector math to combine the East(U) and North(V) wind components
+		windspd[zone] = np.sqrt(
+			np.square(climateForecast[zone]['U10']) +
+			np.square(climateForecast[zone]['V10'])
+		)
+		if zone == '403':
+			windspd[zone] = pd.concat([(remove_nas(climateObsCR['CR']['WSPEED']) * 0.75), windspd[zone]])
+		else:
+			windspd[zone] = pd.concat([(remove_nas(climateObsCR['CR']['WSPEED']) * 0.65), windspd[zone]])
+
+		#  a bit of trig to map the wind vector components into a direction
+		#  𝜙 =180+(180/𝜋)*atan2(𝑢,𝑣)
+		winddir[zone] = 180 + np.arctan2(
+				climateForecast[zone]['U10'],
+				climateForecast[zone]['V10']
+			) * 180 / np.pi
+		winddir[zone] = pd.concat([remove_nas(climateObsCR['CR']['WDIR']), winddir[zone]])
+
+		logger.info(f'WINDSP for zone {zone}')
+		logger.info(print_df(windspd[zone]))        
+		logger.info(f'WINDDIR for zone {zone}')
+		logger.info(print_df(winddir[zone]))        
+
+	SUBPLOT_PACKAGES['wind speed'] = {'labelled_data':windspd,
+										'ylabel':'m/s',
+										'title':'Wind Speed',
+										'fc_start':forecast_start,
+										'row':1,
+										'col':1,
+										'axis':AXES}
+	
+	SUBPLOT_PACKAGES['wind direction'] = {'labelled_data':windspd,
+										'ylabel':'degrees clockwise from North',
+										'title':'Wind Direction',
+										'fc_start':forecast_start,
+										'row':1,
+										'col':2,
+										'axis':AXES}
+
+	# Write Wind Speed and Direction File
+	#
+	for zone in windspd.keys():
+		filename = f'WS_WD_{zone}.dat'
+		logger.info('Generating Wind Speed and Direction File: '+filename)
+
+		with open(os.path.join(THEBAY.infile_dir, filename), mode='w', newline='') as output_file:
+
+			THEBAY.addfile(fname=filename)        # remember generated bay files
+
+			# output the header text
+			output_file.write('!-----------------------------------------------------!\n')
+			output_file.write('! Written by AEM3D_prep_FEE_IAM                           !\n')
+			output_file.write('! Bay ID: '+ THEBAY.bayid + '                            !\n')
+			#output_file.write('! Bay Source: ' + bs_name + '                         !\n')
+			output_file.write('!-----------------------------------------------------!\n')
+			output_file.write('2 data sets\n')
+			output_file.write('0 seconds between data\n')
+			output_file.write(f'0            {zone}          {zone}\n')
+			output_file.write('TIME         WIND_SPEED	  WIND_DIR\n')
+
+			# output the ordinal date and flow value time dataframe columns
+			pd.concat([
+				seriesIndexToOrdinalDate(windspd[zone]),
+				seriesIndexToOrdinalDate(winddir[zone])],
+				axis=1).to_csv(
+				path_or_buf = output_file,
+				float_format='%.3f',
+				sep=' ',
+				index=True, header=False)
+	#
+	#   end wind file
+
+
+
+	###########################################################################################
+	#
+	#   Relative Humidity : WRF, Calculated from Q2
+	#
+
+	rhum = {}
+	rhum['403'] = pd.concat([remove_nas(climateObsCR['CR']['RH2']) * .01, climateForecast['403']['RH2'] * .01])   
+	
+	logger.info(f'RH2')
+	logger.info(print_df(rhum['403']))
+
+	SUBPLOT_PACKAGES['relative humidity'] = {'labelled_data':rhum,
+										'ylabel':'Relative Humidity (%)',
+										'title':'Relative Humidity at 2 Meters',
+										'fc_start':forecast_start,
+										'row':1,
+										'col':3,
+										'axis':AXES}
+
+	#   Write Relative Humidity File
+	for zone in rhum.keys():
+		filename = f'RELHUM_{zone}.dat'
+		logger.info('Generating Rel Humidity File: '+filename)
+		writeFile(
+			os.path.join(THEBAY.infile_dir, filename),
+			THEBAY.bayid,
+			zone,
+			"REL_HUM",
+			seriesIndexToOrdinalDate(rhum[zone]))
+		THEBAY.addfile(fname=filename)
+
+
+	#   Write Air Temp File
+	for zone in air_temp.keys():
+		filename = f'AIRTEMP_{zone}.dat'
+		logger.info('Generating Air Temp File: '+filename)
+		writeFile(
+			os.path.join(THEBAY.infile_dir, filename),
+			THEBAY.bayid,
+			zone,
+			"AIR_TEMP",
+			seriesIndexToOrdinalDate(air_temp[zone]))
+		THEBAY.addfile(fname=filename)
+
+
+	# Write ShortwaveRad File
+	# Load the CSV that nudges SWR values based on Day Of Year
+	swradjust = pd.read_csv(os.path.join(THEBAY.template_dir, 'SolarRadiationFactor_MB.csv'))
+	# Use the passed forecast date to only nudge the observed values before the forecast
+	swradjust['NudgeObs'] = swradjust['Ratio (MB/CR)']  # copy entire original nudge column
+	dayofyear = int(forecast_start.strftime('%j'))
+	swradjust.loc[swradjust['Day of Year'] >= dayofyear,'NudgeObs'] = 1.0   # don't adjust forecast data
+
+	swdown_plot_data = {}
+	for zone in climateForecast.keys():
+		filename = f'SOLAR_{zone}.dat'
+		logger.info('Generating Short Wave Radiation File: '+filename)
+		full_swdown_series = pd.concat([remove_nas(climateObsCR['CR']['SWDOWN']), climateForecast[zone]['SWDOWN']])
+		swdown_plot_data[zone] = full_swdown_series
+		swdown_series = seriesIndexToOrdinalDate(full_swdown_series)
+		
+		# build a dataframe to nudge the data series
+		swdown_df = pd.concat([swdown_series.index.to_series(),swdown_series], axis = 1)
+		swdown_df.columns = ['TIME', 'SWDOWN']
+		swdown_df['SWNUDGED'] = swdown_df.apply(ordinalnudgerow, args = ('SWDOWN', swradjust), axis = 1)
+
+		logger.info(f'SWDOWN for zone {zone}')
+		logger.info(print_df(swdown_df))
+		
+		writeFile(
+			os.path.join(THEBAY.infile_dir, filename),
+			THEBAY.bayid,
+			zone,
+			"SOLAR_RAD",
+			swdown_df['SWNUDGED']
+		)
+
+		# this is the raw solar_rad data, without the data nudge
+		filenameorig = 'raw'+filename
+		writeFile(
+			os.path.join(THEBAY.infile_dir, filenameorig),
+			THEBAY.bayid,
+			zone,
+			"SOLAR_RAD",
+			swdown_series
+		)
+
+		THEBAY.addfile(fname=filename)
+
+	SUBPLOT_PACKAGES['short wave rad'] = {'labelled_data':swdown_plot_data,
+										'ylabel':'W/m^2',
+										'title':'Short-Wave Downward Radiation (Un-nudged)s',
+										'fc_start':forecast_start,
+										'row':1,
+										'col':4,
+										'axis':AXES}
+
+	###
+	#
+	#   Generate Lake Level Regression from Temp and Flow Derived Terms
+	#       Calculate lake level based on previous regression model results.
+	#		Ported from original IAM/tools/EFDC_file_prep/EFDC_file_prep.R
+	#       The regression model equation for lake level is:
+	#       LakeLevel = 94.05887 +
+	#           0.007910834(temperature) +
+	#           7.034478e-05 (discharge) +
+	#           0.003396492(discharge7days) +
+	#           0.01173037(discharge30days) +
+	#           0.0258206(discharge60days)
+	#
+	###
+	logger.info('Generating Lake Levels')
+   
+	########################################### Formerly...
+	# # TODO: Which to use?  streamflow_cms or streamflow_adj_cms
+	# streamflow_unadj_cms = flowdf['msflow'] / 0.98
+	# flowdf['flowmean_07'] = streamflow_unadj_cms.rolling(window=7,min_periods=1).mean() # moving average over 7 days
+	# flowdf['flowmean_30'] = streamflow_unadj_cms.rolling(window=30,min_periods=1).mean() # moving average over 30 days
+	# flowdf['flowmean_60'] = streamflow_unadj_cms.rolling(window=60,min_periods=1).mean() # moving average over 60 days
+
+	######################################### Now...
+	lakeLevel_df = pd.DataFrame({'ordinaldate': THEBAY.flowdf['ordinaldate'],
+								 'msflow': THEBAY.flowdf['msflow'],
+								 'flowmean_07': THEBAY.flowdf['msflow'].rolling(window=7,min_periods=1).mean(),
+								 'flowmean_30': THEBAY.flowdf['msflow'].rolling(window=30,min_periods=1).mean(),
+								 'flowmean_60': THEBAY.flowdf['msflow'].rolling(window=60,min_periods=1).mean()},
+								 index=pd.DatetimeIndex(THEBAY.flowdf.index, name='time')
+								 )
+	logger.info(f'lakelevel_df pre merge')
+	logger.info(print_df(lakeLevel_df))
+	
+	###################
+	# Need to get parity with timestamps between flow and temp
+	## Formerly...
+	# # drop any null leap days generated by resample and convert to F
+	# wrfdailyraw = air_temp['403'].resample('D').mean()
+	# wrfdailyF = 32 + 1.8 * wrfdailyraw.dropna(axis=0, inplace=False, how='any')
+	# TemperatureF = wrfdailyF.to_numpy()
+	
+	## Now...
+	### Need to merge these df's together on time stamp
+	lakeLevel_df = pd.merge(lakeLevel_df, air_temp['403'], on='time', how='inner')
+	logger.info(f'lakelevel_df after merge')
+	logger.info(print_df(lakeLevel_df))
+
+	print('Calculating Lake Levels')
+	lakeLevel_df['LakeLevel'] = 94.05887 + 0.007910834 * lakeLevel_df['T2'] + \
+		7.034478e-05 * lakeLevel_df['msflow'] + \
+		0.003396492 * lakeLevel_df['flowmean_07'] + \
+		0.01173037 * lakeLevel_df['flowmean_30'] + \
+		0.0258206 * lakeLevel_df['flowmean_60']
+
+	print('Calculating Lake Level Bias')
+	# Next, apply the bias correction from the bias correction quadratic regression on the residuals against the observed lake level:
+	bias_correction = -358.51020205 + \
+		7.16150850 * lakeLevel_df['LakeLevel'] + \
+		-0.03570562 * np.power(lakeLevel_df['LakeLevel'],2)
+
+	lakeLevel_df['LakeLevel_corrected'] = lakeLevel_df['LakeLevel'] + bias_correction
+
+
+	# AEM3D lake input defined as meters above 93ft - do the math
+	lakeLevel_df['LakeLevel_delta'] = (lakeLevel_df['LakeLevel_corrected'] - 93) * 0.3048
+
+	#
+	#   write out lake level file
+	#
+	logger.info('Lake Level (m) above 93ft')
+	logger.info(lakeLevel_df['LakeLevel_delta'].describe(percentiles=[]))
+
+	filename = 'Lake_Level.dat'
+	logger.info('Writing Lake Level File '+filename)
+
+	pathedfile = os.path.join(THEBAY.infile_dir, filename)
+	with open(pathedfile, mode='w', newline='') as output_file:
+
+		THEBAY.addfile(fname=filename)        # remember generated bay files
+
+		# output the header text
+		output_file.write(
+			'!-----------------------------------------------------!\n')
+		output_file.write(
+			'! Written by AEM3D_prep_FEE_IAM                           !\n')
+		output_file.write('! Bay ID: ' + THEBAY.bayid +
+						  '                            !\n')
+		output_file.write(
+			'! values in (m) above 93 ft                           !\n')
+		output_file.write(
+			'!-----------------------------------------------------!\n')
+		output_file.write('1 data sets\n')
+		output_file.write('0 seconds between data\n')
+		output_file.write('0    300\n')
+		output_file.write('TIME	  HEIGHT\n')
+
+		# output the ordinal date and flow value time dataframe columns for AEM3D and as .csv
+		lakeLevel_df.to_csv(path_or_buf=output_file, columns=['ordinaldate', 'LakeLevel_delta'], float_format='%.3f',
+					  sep=' ', index=False, header=False)
+		# lakeLevel_df.to_csv(path_or_buf='lakeheight.csv', float_format='%.3f', sep=' ', index=False, header=True)
+
+	##
+	#
+	#   End of Lake Level From Temp and Flow Generation
+	#
+	##
+
+
+def gensalinefile(theBay):
+	#
+	#   Salinity data time series
+	#
+	generate_file_from_template('salinity.template.txt',
+								'Inflows_Salinity.dat',
+								theBay,
+								{'source_id_list': '  '.join(theBay.sourcelist),
+								 'firstdate': theBay.FirstDate,
+								 'lastdate': theBay.LastDate
+								})
+
+
+def genboundaryfile(theBay):
+	#
+	#   P boundary condition data time series
+	#
+	generate_file_from_template('bc_p.template.txt',
+								'OpenBC_P.dat',
+								theBay,
+								{'firstdate': theBay.FirstDate,
+								 'lastdate': theBay.LastDate
+								})
+		
+
+def gentracerfiles(theBay):
+	#
+	# Write Tracer Files - fixed series, use templates and set $year
+	#
+
+	for templateFile in [f for f in os.listdir(theBay.template_dir) if 'Tracer' in f]:
+		generate_file_from_template(templateFile,
+									os.path.splitext(templateFile)[0]+'.dat',
+									theBay,
+									{'firstdate': theBay.FirstDate,
+									 'lastdate': theBay.LastDate
+									})
+	
+	generate_file_from_template('tracer_release.template',
+								'tracer_release.dat',
+								theBay,
+								{'firstdate': theBay.FirstDate,
+								 'lastdate': theBay.LastDate
+								},
+								'update_file')
+	#
+	# End of Tracer File Generation
+	#
+
+
+def gencntlfile(forecast_start, theBay, spinup_date):
+
+	# Calculate 1 hour in iterations
+	hourIter = int(86400 / AEM3D_DEL_T / 24)
+	# Calculate iterations: Time between forecast date and spinup start + 7 more days
+	iterations = int((forecast_start - (spinup_date + dt.timedelta(days=1))).total_seconds() / AEM3D_DEL_T) + (7 * 24 * hourIter)
+
+	logger.info(f'Configuring AEM3D to run {iterations} iterations')
+	
+	with open(os.path.join(theBay.template_dir, 'aem3dcntl.template.txt'), 'r') as file:
+		template = Template(file.read())
+
+	# control file is written to runtime directory
+	pathedfile = os.path.join(theBay.run_dir, 'run_aem3d.dat')
+	with open(pathedfile, 'w') as output_file:
+		output_file.write(template.substitute(**{
+			'start_date': theBay.FirstDate,
+			'del_t': AEM3D_DEL_T,
+			# number of 300s steps in a 364 days (year minus 1 day, because 1st day is a start, not a step)
+			# 27936 for 97 days (97*24*12)
+			'iter_max': iterations,
+			'hour': hourIter,
+			'eighthours': (hourIter * 8),
+			'daysthirty': (hourIter * 24 * 30)
+			}))
+
+		# update the control file with all generated input files
+		output_file.write(
+			'! --------------------------------------------------------------- !\n')
+		output_file.write(
+			'! Input file names                                                 !\n')
+		output_file.write('\''+os.path.split(theBay.infile_dir)[1] +
+						'\'                                     infile_dir\n')
+		output_file.write(
+			' sparsedata_aem3d.unf                              3D_data_file\n')
+		output_file.write(
+			' usedata_aem3d.unf                             preprocessor_file\n')
+		# output_file.write(
+		#     ' datablock.xml                                     datablock_file\n')
+
+		for f, t in theBay.bayfiles:        # for each filename, filetype
+			output_file.write(' '+f+'              '+t+'\n')
+
+		output_file.write(
+					'!  End                                                            !\n')
+# end of control file generation
+
+
+def gendatablockfile(forecast_start, theBay, spinup_date):
+
+	# Calculate 1 hour in iterations
+	hourIter = int(86400 / AEM3D_DEL_T / 24)
+	# Calculate iteration for forecast start: Time between forecast date and spinup start
+	forecastStartIter = int((forecast_start - (spinup_date + dt.timedelta(days=1))).total_seconds() / AEM3D_DEL_T) + 1
+
+	logger.info(f'Configuring datablock.xml file')
+	generate_file_from_template('datablock.xml.template',
+								'datablock.xml',
+								theBay,
+								{'hour': hourIter,
+								 'sixhours': (hourIter * 6),
+								 'day': (hourIter * 24),
+								 'spinupEnd': (forecastStartIter - 1),
+								 'forecastStart': forecastStartIter
+								},
+								'datablock_file')
+# end of datablock.xml generation
+ 
+def AEM3D_prep_FEE_IAM(settings, theBay):
+
+	# grab settings
+	FORECASTSTART = settings['forecast_start']
+	# default forecast end date is 7 days after forecast start date
+	FORECASTEND = settings['forecast_end']
+	SPINUP = settings['spinup_date']
+	USE_GFS_CSVS = settings['csv']
+	ROOT_DIR = settings['root_dir']
+	# this settings is no longer needed since adopting new directory structure for all production runs
+	# Won't remove it for now but will create an issue
+	DIRFLAG = settings['new_dirs']
+
+	logger.info(f'Processing Bay: {theBay.bayid} for year {theBay.year}')
+
+	# get flow files from hydrology model data
+	getflowfiles(FORECASTSTART, FORECASTEND, theBay, ROOT_DIR, SPINUP, DIRFLAG)
+
+	# generate climate files including lake levels
+	genclimatefiles(FORECASTSTART, FORECASTEND, theBay, USE_GFS_CSVS, ROOT_DIR, SPINUP, DIRFLAG)
+
+	# generate salinity file
+	gensalinefile(theBay)
+
+	# generate boundary condition file
+	genboundaryfile(theBay)
+	
+	# generate tracer files
+	gentracerfiles(theBay)
+
+	# generate the water quality files (waterquality.py script)
+	genwqfiles(theBay)
+
+	# generate the datablock.xml file
+	gendatablockfile(FORECASTSTART, theBay, SPINUP)
+
+	# generate control file
+	gencntlfile(FORECASTSTART, theBay, SPINUP)
+
+	global FIG
+	global SUBPLOT_PACKAGES
+	make_figure(SUBPLOT_PACKAGES)
+	FIG.savefig('weatherVars.png')
+
+	return 0

--- a/models/aem3d/AEM3D_prep_FEE_IAM.py
+++ b/models/aem3d/AEM3D_prep_FEE_IAM.py
@@ -479,8 +479,12 @@ def genclimatefiles(whichbay, settings):
 			# if there is no member num (such as 'short_range/') default to 1 so that there is no timedelta adjust
 			if not member.isdigit():
 				member = '1'
+			# NOTE forecast_end adjustment: between forecast_start and end, we only want 7.5 days of data.
+				# forecast_start will be adjusted based on the NWM member, but end will stay the same
+				# this means that we will be grabbing more data ofr higher members
+				# ex. member 7 uses a GFS adjustment of forecast_start-1.5 days, so will grab 9 days total (1.5+7.5)
 			forecastClimate = gfs_fc_thredds.get_data(forecast_datetime = settings['forecast_start'] - dt.timedelta(hours=(6*(int(member)-1))),
-													end_datetime = settings['forecast_end'] + dt.timedelta(days=1),
+													end_datetime = settings['forecast_end'] + dt.timedelta(hours=12),
 													locations = {'401': (45.00, -73.25),
 																'402': (44.75, -73.25),
 																'403': (44.75, -73.25)},

--- a/models/aem3d/AEM3D_prep_FEE_IAM.py
+++ b/models/aem3d/AEM3D_prep_FEE_IAM.py
@@ -241,7 +241,7 @@ def getflowfiles(whichbay, settings):
 			forecastHydro[location]['streamflow'] = forecastHydro[location]['streamflow'] * 0.0283168
 	
 	elif(settings['hydrology_dataset_forecast'] == 'NOAA_NWM_PROD'):
-		nwm_fc.get_data(forecast_datetime = settings['forecast_start'],
+		forecastHydro = nwm_fc.get_data(forecast_datetime = settings['forecast_start'],
 						end_datetime = settings['forecast_end'] + dt.timedelta(days=1),
 						locations = {"MS":"166176984",
 								     "J-S":"4587092",
@@ -250,6 +250,8 @@ def getflowfiles(whichbay, settings):
 						data_dir = os.path.join(settings['root_dir'], 'hindcastData/'),
 						load_threads = 1,
 						google_buckets = True)
+	else:
+		raise ValueError(f"'{settings['hydrology_dataset_forecast']}' is not a valid hydrology forecast dataset")
 			
 	
 	# Need to adjust for column names

--- a/models/aem3d/AEM3D_prep_FEE_worker.py
+++ b/models/aem3d/AEM3D_prep_FEE_worker.py
@@ -27,7 +27,7 @@ def main():
     prep_path = 'aem3d-run'
 
 
-    SETTINGS = get_args(default_fpath="/gpfs1/home/n/b/nbeckage/ciroh/forecast-workflow/default_settings.json")
+    SETTINGS = get_args()
 
     #THEBAY = IAMBAY(settings['whichbay'])   # Create Bay Object for Bay specified
     THEBAY = IAMBAY(bayid='ILS')   # Create Bay Object for Bay specified
@@ -45,7 +45,7 @@ def main():
     THEBAY.run_dir = prep_path
 
     # Copy current aem3d run template
-    cp('-R', '/netfiles/ciroh/models/aem3d/current/AEM3D-inputs', prep_path)
+    cp('-R', SETTINGS["aem3d_input_dir"], prep_path)
 
     with cd('.'):
 
@@ -58,7 +58,7 @@ def main():
             preprc = AEM3D_prep_FEE_IAM(forecastDate=today, theBay=THEBAY)
             """
             # source the python file prep script
-            preprc = AEM3D_prep_FEE_IAM(settings=SETTINGS, theBay=THEBAY)
+            preprc = AEM3D_prep_FEE_IAM(theBay=THEBAY, settings=SETTINGS)
 
         except Exception as e:
             logger.info('AEM3D_prep_FEE_IAM.py failed. Exiting.')

--- a/models/aem3d/AEM3D_prep_FEE_worker.py
+++ b/models/aem3d/AEM3D_prep_FEE_worker.py
@@ -1,0 +1,81 @@
+#   Worker for preparing the AEM3D Lake Model Inputs
+#       Initial coding branches from the prep_RCA_worker content
+#
+#   Determine runtime specifics -
+#   - the bay of interest (Missisquoi, St. Albans)
+#   - the hydrology model (SWAT, RHESSys)
+
+from lib import cd, logger, IAMBAY
+from .AEM3D_prep_FEE_IAM import *
+from .get_args import get_args
+from sh import cp
+import os
+import sys
+import datetime as dt
+import traceback
+
+
+def is_num(value):
+    try:
+        int_ed = int(value)
+
+        return True
+    except:
+        return
+
+def main():
+    prep_path = 'aem3d-run'
+
+
+    SETTINGS = get_args(default_fpath="/gpfs1/home/n/b/nbeckage/ciroh/forecast-workflow/default_settings.json")
+
+    #THEBAY = IAMBAY(settings['whichbay'])   # Create Bay Object for Bay specified
+    THEBAY = IAMBAY(bayid='ILS')   # Create Bay Object for Bay specified
+
+
+    # These two settings return datetime objs set to midnight already
+    THEBAY.FirstDate = datetimeToOrdinal(SETTINGS['spinup_date'])
+    THEBAY.LastDate = datetimeToOrdinal(SETTINGS['forecast_end'])
+
+
+    ## Need dataframes for hydrology from Missisquoi, Mill, JewittStevens
+
+    THEBAY.infile_dir = os.path.join(prep_path, 'infiles')
+    THEBAY.template_dir = os.path.join(prep_path, 'TEMPLATES')
+    THEBAY.run_dir = prep_path
+
+    # Copy current aem3d run template
+    cp('-R', '/netfiles/ciroh/models/aem3d/current/AEM3D-inputs', prep_path)
+
+    with cd('.'):
+
+        try:
+            # Create Dir for infiles
+            if not os.path.exists(THEBAY.infile_dir):
+                os.makedirs(THEBAY.infile_dir)
+
+            """
+            preprc = AEM3D_prep_FEE_IAM(forecastDate=today, theBay=THEBAY)
+            """
+            # source the python file prep script
+            preprc = AEM3D_prep_FEE_IAM(settings=SETTINGS, theBay=THEBAY)
+
+        except Exception as e:
+            logger.info('AEM3D_prep_FEE_IAM.py failed. Exiting.')
+            logger.info(traceback.print_exc())
+            sys.exit(1)
+
+        # # build this tar with everything under the run directory, but without the run directory itself
+        # tar(
+        #     'czf',
+        #     '%s-AEM3D-inputs.tar.gz' % SCENARIO.id,
+        #     '-C'
+        #     'AEM3D-inputs',
+        #     '.'
+        # )
+        # mv('%s-AEM3D-inputs.tar.gz' % SCENARIO.id, '../')
+
+    logger.info('Fin')
+
+if __name__ == '__main__':
+    main()

--- a/models/aem3d/AEM3D_worker.py
+++ b/models/aem3d/AEM3D_worker.py
@@ -1,3 +1,4 @@
+from .get_args import get_args
 from lib import (
     cd,
     logger,
@@ -108,11 +109,11 @@ from sh import Command, rm
 
 
 def main():
-    # settings = parse_args(sys.argv[1:])
+    SETTINGS = get_args()
     # scenario = IAMScenario.from_id(settings['scenario'])
 
     # pick_aem3d_bin(settings)
-    aem3d = Command("/gpfs1/home/n/b/nbeckage/ciroh/aem3d-1.1.2-535/aem3d_openmp.exe")
+    aem3d = Command(SETTINGS["aem3d_command_path"])
 
     with cd('aem3d-run'):        # the working dir for the run
 

--- a/models/aem3d/waterquality.py
+++ b/models/aem3d/waterquality.py
@@ -237,6 +237,8 @@ def genwqfiles (theBay):
         #TODO: Implement BREE2021Seg
         #TODO: Move all this junk to THEBAY, choose cqVersion at THEBAY creation
 
+		# make wQ a settings, have peter's stuff be an option
+		# if cqVersion = "islesRF"
         if cqVersion == 'Clelia':
             # Clelia TP Concentration - Discharge Relationship
             #   Same for ALL ILS inputs!!


### PR DESCRIPTION
- Implemented climate and hydrology dataset settings in new version of `AEM3D_prep_FEE_IAM.py` for scenario runs
- Made `gfs_fc_thredds.get_data()` call grab a variable amount of data depending on NWM forecast member such that the function will always return 7.5 days of data from `forecast_start` to `forecast_end`
- Added bad file check for `gfs_fc_thredds.process_gfs_data()` (see commit [4a8d693](https://github.com/CIROH-UVM/forecast-workflow/commit/4a8d69317034c5fb4d4b9e91b9ecc524f171e355) for details)
- Created new `batch/` directory to store files for scenario configurations and launches, as well as data download scripts on the VACC