### PR TITLE
Create AORC Data Acquisition Module

### DIFF
--- a/data/nwmretro_forcings_ob.py
+++ b/data/nwmretro_forcings_ob.py
@@ -38,7 +38,7 @@ def get_data(start_date,
 										Alternative return type is "dataframe", which smashes all data into a single dataframe muliIndex'd by station ID, then timestamp
 		
 		Returns:
-		
+		NWM retrospective forcings timeseries data for the given locations in the format specified by return_type
 	'''
 	start_date = parse_to_datetime(start_date)
 	end_date = parse_to_datetime(end_date)


### PR DESCRIPTION
PR to close #63. Create a new file `aorc_obs.py` that contains a `get_data()` function to access data from the AORC  Amazon Web bucket. Also included a helper function to smash a dictionary of dataframes into a single dataframe that includes latitude and longitude. A couple differences from previous `get_data()`'s to note:
- There are two valid `return_type` arguments, 'series' and 'dataframe'
- 'series' will return the nested dictionary of pandas series, just as before
- 'dataframe' will return a single-layer dictionary, where the keys are location names and values are timeseries dataframes for those locations

I decided to change the default `return_type` argument to 'series' rather than 'dict' because both return types directly return a dictionary, which I think is a good starting point for most future use cases. 