### PR TITLE
Bug fixes and other updates to prepare for FEEv2

### DIFF
--- a/batch/experiment_configTEMPLATE.json
+++ b/batch/experiment_configTEMPLATE.json
@@ -11,5 +11,6 @@
 	"hydrology_dataset_observed" : "USGS_IV",
 	"hydrology_dataset_forecast" : "NOAA_NWM_PROD",
 	"nwm_forecast_member" : "<nwm_forecast_member>",
+	"data_dir" : "/netfiles/ciroh/7dayHABsHindcast/hindcastData/",
 	"aem3d_command_path" : "<path_to_aem3d>"
 }

--- a/batch/launchExperiment.py
+++ b/batch/launchExperiment.py
@@ -53,7 +53,7 @@ for year in years:
 		config['spinup_date'] = dt.datetime(date.year, spinup_month_and_day.month, spinup_month_and_day.day).strftime('%Y%m%d')
 		config['forecast_start'] = date.strftime('%Y%m%d')
 		config['forecast_end'] = (date + dt.timedelta(days=7)).strftime('%Y%m%d')
-		config['root_dir'] = root_dir
+		config['data_dir'] = experiment_launch_params['data_dir']
 		config['weather_dataset_observed'] = experiment_launch_params['weather_dataset_observed']
 		config['weather_dataset_forecast'] = experiment_launch_params['weather_dataset_forecast']
 		config['hydrology_dataset_observed'] = experiment_launch_params['hydrology_dataset_observed']

--- a/batch/launchExperiment.py
+++ b/batch/launchExperiment.py
@@ -10,7 +10,7 @@ import models.aem3d.get_args as get_args
 '''
 Script to Launch Model Runs for a given hindcast scenario
 '''
-# directory in ehcih this .py script is located
+# directory in which this .py script is executed from - should be a scenario dir according to FEE protocol
 orig = os.getcwd()
 
 # read in the experiment-spoecific config file from the command line
@@ -49,7 +49,7 @@ for year in years:
 			continue
 		os.makedirs(scenario_dir_date)
 		os.chdir(scenario_dir_date)
-
+		
 		config['spinup_date'] = dt.datetime(date.year, spinup_month_and_day.month, spinup_month_and_day.day).strftime('%Y%m%d')
 		config['forecast_start'] = date.strftime('%Y%m%d')
 		config['forecast_end'] = (date + dt.timedelta(days=7)).strftime('%Y%m%d')

--- a/batch/launchScenarioTEMPLATE.sh
+++ b/batch/launchScenarioTEMPLATE.sh
@@ -8,15 +8,14 @@
 #SBATCH --time=30:00:00
 #SBATCH --job-name=<YOUR_JOB_NAME>
 #SBATCH --output=%x_%j.out
-#SBATCH --mail-type=FAIL
+#SBATCH --mail-type=ALL
 
 source /users/n/b/nbeckage/miniconda3/etc/profile.d/conda.sh
+# source /users/p/c/pclemins/usr/local/miniforge3/etc/profile.d/conda.sh
 conda activate forecast
 
 # change to whatever directory you want to put your scenario runs in
-# currently VACC speciifc
 cd /netfiles/ciroh/7dayHABsHindcast/<SCENARIO_DIR>/
 
 # note that you must have an experiment-specific configuration file in your scenario directory
 python ../launchExperiment.py experiment_config.json
-

--- a/batch/submitTEMPLATE.sh
+++ b/batch/submitTEMPLATE.sh
@@ -12,6 +12,7 @@
 
 set -x
 
+# source /users/p/c/pclemins/usr/local/miniforge3/etc/profile.d/conda.sh
 source /users/n/b/nbeckage/miniconda3/etc/profile.d/conda.sh
 conda activate forecast
 # export PYTHONPATH=/users/p/c/pclemins/repos/forecast-workflow

--- a/default_settings.json
+++ b/default_settings.json
@@ -16,6 +16,6 @@
 	"nwm_forecast_member" : "medium_range_mem1",
 	"csv" : false,
 	"data_dir" : "/netfiles/ciroh/7dayHABsHindcast/hindcastData/",
-	"aem3d_input_dir" : "/netfiles/ciroh/models/aem3d/current/AEM3D-inputs",
+	"aem3d_input_dir" : "/netfiles/ciroh/models/aem3d/v5-20240518/AEM3D-inputs",
 	"aem3d_command_path" : "/usr/local/aem3d-1.1.2-535/aem3d_openmp.exe"
 }

--- a/default_settings.json
+++ b/default_settings.json
@@ -15,7 +15,7 @@
 	"hydrology_dataset_forecast" : "NOAA_NWM_PROD",
 	"nwm_forecast_member" : "medium_range_mem1",
 	"csv" : false,
-	"root_dir" : "/netfiles/ciroh/7dayHABsHindcast/",
+	"data_dir" : "/netfiles/ciroh/7dayHABsHindcast/hindcastData/",
 	"aem3d_input_dir" : "/netfiles/ciroh/models/aem3d/current/AEM3D-inputs",
 	"aem3d_command_path" : "/usr/local/aem3d-1.1.2-535/aem3d_openmp.exe"
 }

--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -50,7 +50,7 @@ FIG.supxlabel('Datetime')
 for i in range(0,5):
 	for label in AXES[1,i].get_xticklabels():
 		label.set_rotation(45)
-FIG.delaxes(AXES[0,4])
+# FIG.delaxes(AXES[0,4])
 
 def get_climate_zone_keys(dict):
 	return [zone for zone in dict.keys() if int(int(zone) / 100) == 4]
@@ -1185,6 +1185,16 @@ def genclimatefiles(whichbay, settings):
 			lake_ht_series
 	)
 	THEBAY.addfile(fname=filename)
+
+	logger.info(f'lake_height:{lake_height}')
+	# adding Lake Level plot package
+	SUBPLOT_PACKAGES['lake level'] = {'labelled_data':{'300':lake_height},
+									'ylabel':'Lake Level (m) above 93ft',
+									'title':'Lake Level',
+									'fc_start':settings['forecast_start'],
+									'row':0,
+									'col':4,
+									'axis':AXES}
 	
 	# pathedfile = os.path.join(THEBAY.infile_dir, filename)
 	# with open(pathedfile, mode='w', newline='') as output_file:

--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -801,6 +801,8 @@ def genclimatefiles(whichbay, settings):
 		#   and / 1000 to get mm to m, so, in all, * 86.4
 		#   GFS Ref: https://www.nco.ncep.noaa.gov/pmb/products/gfs/gfs.t00z.pgrb2.0p25.f003.shtml
 		bay_rain[zone] = pd.concat([observedClimate[zone]['RAIN'], forecastClimate[zone]['RAIN']])
+		# give series a name... beacuse pandas wants one for the merge below
+		bay_rain[zone] = bay_rain[zone].rename('RAIN')
 
 		print(air_temp[zone])
 		TEMP = air_temp[zone].reindex(bay_rain[zone].index, method='nearest')
@@ -834,7 +836,7 @@ def genclimatefiles(whichbay, settings):
 		snowcalc_df = pd.merge(bay_rain[zone], snowcoeff, on='time', how='inner')
 		logger.info('snowcalc_df')
 		logger.info(print_df(snowcalc_df))
-		bay_snow[zone] = snowcalc_df['RAIN (inches)'] * snowcalc_df['T2']
+		bay_snow[zone] = snowcalc_df['RAIN'] * snowcalc_df['T2']
 		
 		# remove duplicate indices from bay_snow, bay_rain and TEMP
 		# duplicated timestamps was creating some concat and .loc issues down the line
@@ -1159,6 +1161,8 @@ def genclimatefiles(whichbay, settings):
 
 	# Calculate misalignment between first predicted and last observered, and adjust entire prediction that amount
 	htoffset = observedClimate['300']['LAKEHT'].iloc[-1] - forecastClimate['300']['LAKEHT'].iloc[0]
+	logger.info(f"Last observed = {observedClimate['300']['LAKEHT'].index[-1]}, {observedClimate['300']['LAKEHT'].iloc[-1]}")
+	logger.info(f"First estimated = {forecastClimate['300']['LAKEHT'].index[0]}, {forecastClimate['300']['LAKEHT'].iloc[0]}")
 	logger.info('Lake Height Prediction Offset = ' + str(htoffset))
 	forecastClimate['300']['LAKEHT'] = forecastClimate['300']['LAKEHT'] + htoffset 
 	lake_height = pd.concat([observedClimate['300']['LAKEHT'],forecastClimate['300']['LAKEHT']])
@@ -1180,7 +1184,7 @@ def genclimatefiles(whichbay, settings):
 			"HEIGHT",
 			lake_ht_series
 	)
-
+	THEBAY.addfile(fname=filename)
 	
 	# pathedfile = os.path.join(THEBAY.infile_dir, filename)
 	# with open(pathedfile, mode='w', newline='') as output_file:

--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -224,7 +224,7 @@ def getflowfiles(whichbay, settings):
 								     "J-S":"4587092",
 								     "Mill":"4587100"},
 						forecast_type = settings['nwm_forecast_member'],
-						data_dir = os.path.join(settings['root_dir'], 'hindcastData/'),
+						data_dir = settings['data_dir'],
 						load_threads = 1,
 						google_buckets = True)
 
@@ -546,9 +546,7 @@ def genclimatefiles(whichbay, settings):
 		observedClimateCR = femc_ob.get_data(start_date = adjusted_spinup,
 										end_date = settings['forecast_start'],
 										locations = {'401':'ColReefQAQC'},
-										# TODO: create data_dir as a new setting and implement
-										# data_dir = os.path.join(settings['root_dir'], 'hindcastData/'))
-										data_dir = os.path.join('/netfiles/ciroh/7dayHABsHindcast', 'hindcastData/'))
+										data_dir = settings['data_dir'])
 		
 		###### FEMC+LCD DATA ADJUSTMENTS HERE ######
 		# make additional location dictionaries here rather than call for the same location multiple times in get_data()'s
@@ -613,9 +611,7 @@ def genclimatefiles(whichbay, settings):
 		forecastClimateCR = femc_ob.get_data(start_date = settings['forecast_start'],
 										end_date = adjusted_end_date,
 										locations = {'401':'ColReefQAQC'},
-										# TODO: create data_dir as a new setting and implement
-										# data_dir = os.path.join(settings['root_dir'], 'hindcastData/'))
-										data_dir = os.path.join('/netfiles/ciroh/7dayHABsHindcast', 'hindcastData/'))
+										data_dir = settings['data_dir'])
 		
 		
 		# copy data from 401 for 402, 403. Make sure it's a deep copy, not memeory reference
@@ -667,7 +663,7 @@ def genclimatefiles(whichbay, settings):
 			forecastClimate = {}
 			for zone in ['401', '402', '403']:
 				forecastClimate[zone] = pd.read_csv(
-							os.path.join(settings['root_dir'], f'hindcastData/gfs{zone}.csv'),
+							os.path.join(settings['data_dir'], f'gfs{zone}.csv'),
 							index_col='time',
 							parse_dates=True)
 		else:
@@ -687,7 +683,7 @@ def genclimatefiles(whichbay, settings):
 													locations = {'401': (45.00, -73.25),
 																'402': (44.75, -73.25),
 																'403': (44.75, -73.25)},
-													data_dir = os.path.join(settings['root_dir'], 'hindcastData/'),
+													data_dir = settings['data_dir'],
 													load_threads = 1)
 			
 			###### GFS DATA ADJUSTMENTS HERE ######

--- a/models/aem3d/get_args.py
+++ b/models/aem3d/get_args.py
@@ -75,9 +75,9 @@ def check_values(settings_dict, defaults=False):
 	# don't need to check csv flag, as default is false, and if the flag is passed, it will change to true. Trying to pass a
 	#  string or number for --csv will throw an error as an unrecognized bool
 	if not defaults:	
-		# check to see if root dir exists
-		if not os.path.isdir(settings_dict['root_dir']):
-			raise ValueError(f"path '{settings_dict['root_dir']}' does not exist")
+		# check to see if data dir exists
+		if not os.path.isdir(settings_dict['data_dir']):
+			raise ValueError(f"path '{settings_dict['data_dir']}' does not exist")
 		# check to see if aem3d input dir exists
 		if not os.path.isdir(settings_dict['aem3d_input_dir']):
 			raise ValueError(f"path '{settings_dict['aem3d_input_dir']}' does not exist")
@@ -107,7 +107,7 @@ def get_cmdln_args():
 	parser.add_argument('--hdf', type=str, help='forecasted hydrological dataset to use for model run')
 	parser.add_argument('--mem', type=str, help='NWM forecast member to use IFF using a NWM production dataset')
 	parser.add_argument('--csv', action='store_true', help="flag determining whether or not to use GFS/NWM CSV's. Default is False.")
-	parser.add_argument('--root', type=str, help='root dir containing forecastScripts, forecastRuns, forecastData')
+	parser.add_argument('--data', type=str, help='directory containing meteorology & hydrology data for workflow, i.e. forecastData, hindcastData, etc.')
 	parser.add_argument('--aem_in', type=str, help="absolute path to 'AEM3D-inputs/'")
 	parser.add_argument('--aem_ex', type=str, help="absolute path to AEM3D executable, 'aem3d_openmp.exe'")
 	# parser.add_argument('--old_dirs', action='store_false', help="flag determining whether or not to use post-update dir structure. Default is True. IOW, pass this flag to use old dir structure")

--- a/models/aem3d/get_args.py
+++ b/models/aem3d/get_args.py
@@ -2,7 +2,7 @@ import argparse
 from datetime import date, datetime, timedelta
 import inspect
 import json
-from lib import parse_to_datetime
+from data.utils import parse_to_datetime
 import os
 
 """


### PR DESCRIPTION
Changes to note:
- Franklin airport cloud data is now supplemented with BTV cloud data when there are large gaps in the Franklin timeseries
- workflow no longer has `root_dir` arg; instead there's a `data_dir` to specify where `prep_IAM` should look for/download data (GFS, NWM). Now you can run `forecast-workflow` from any dir you wish;
- fixed CFL bug - added `writefile()` call for lake level
- added lake level plot to `weatherVars.png`