### PR TITLE
Fix incorrect units in streamflow column names, implement changes downstream

### DIFF
--- a/data/caflow_ob.py
+++ b/data/caflow_ob.py
@@ -83,7 +83,7 @@ def get_data(start_date,
 
 		# Subset to the columns of interest
 		df = df[['Débit (m³/s)']]
-		df.columns = ['streamflow']
+		df.columns = [list(variables.keys())[0]]
 		df.index.name = 'time'
 		#print(df)
 

--- a/models/aem3d/waterquality.py
+++ b/models/aem3d/waterquality.py
@@ -257,13 +257,16 @@ def genwqfiles (theBay):
 
 		# I think it's appropriate to have this be hard-coded, as it shouldn't change... unless someone runs our workflow outside of the VACC
 		rf_models_dir = '/netfiles/ciroh/models/cq_randomforest_peterisles/current/'
+		# rf_models_dir = '/netfiles/ciroh/nbeckage/rfcq/'
+
+		print(f"Q DATAFRAME:")
+		print(Q)
 		# make wQ a settings, have peter's stuff be an option
 		if cqVersion == 'Clelia':
 			# Clelia TP Concentration - Discharge Relationship
 			#   Same for ALL ILS inputs!!
 			zTP = (flows['MS']['streamflow'] - 159.78) / 132.64
 			phosdf['TP'] =  ( 0.011001 * np.power(zTP,2) + 0.073104 * zTP + 0.091528 ) * p_redux
-			
 		elif cqVersion == 'islesRF':
 			rf_tp_dir = os.path.join(rf_models_dir, "TP")
 			Q_features = add_features(pd.DataFrame(Q))

--- a/models/islesRF/cqrf.py
+++ b/models/islesRF/cqrf.py
@@ -53,7 +53,7 @@ def to_metricQ(streamflow_dict, streamflow_colname='streamflow'):
 		metric_q_dfs[location] = metric_q_df
 	return metric_q_dfs
 
-def add_features(data, streamflow_colname='streamflow'):
+def add_features(data, streamflow_colname='streamflow (m³/s)'):
 	'''
 	Function to add features to a daily discharge dataframe for a USGS gauge. Features added are the same as those used by Isles, 2023 (https://doi.org/10.1016/j.watres.2023.120876)
 	Exact specifications for how features were engineered can be found in the code contained in the supplmentary material of said paper.


### PR DESCRIPTION
Two bugs to squash here:
1. `caflow_ob.py`: changing the key of the `variables` argument for `caflow_ob.get_data()` threw an error as 'streamflow' was hardcoded in the function body. This was corrected by having the function infer the variable name from the `variable` dictionary.
2. `cqrf.py`: edited `to_metricQ()` so that it changes the streamflow units from cubic feet to cubic meters per second in the column name of the returned dataframes. Also had to flatten `ca_discharge` from a nested dictionary into a single-layer dictionary in order to combine with metric-converted usgs discharge