### PR TITLE
Revamp streamflow pre-processing for AEM3D

### DIFF
--- a/data/caflow_ob.py
+++ b/data/caflow_ob.py
@@ -83,7 +83,7 @@ def get_data(start_date,
 
 		# Subset to the columns of interest
 		df = df[['Débit (m³/s)']]
-		df.columns = ['streamflow']
+		df.columns = [list(variables.keys())[0]]
 		df.index.name = 'time'
 		#print(df)
 

--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -169,7 +169,6 @@ def writeCloudCover(climate, THEBAY):
 #
 ##########################################################################
 
-
 def getflowfiles(whichbay, settings):
 	'''
 	getflowfiles : Get hydrology model flow for Bay Inflow
@@ -324,18 +323,18 @@ def adjustCRTemp(air_data):
 	# S.E.T. - 20240206 - Adjust Colchester Reef Observed temp by month for the Missisquoi Bay Zone (401)
 	# the adjustment, by month, to apply to CR data for use in MissBay
 	tempadjust = {
-    	1 : -2.6,
-    	2 : -2.4,
-    	3 : -0.7,
-    	4 : 0.8,
-    	5 : 1.3,
-    	6 : 0.8,
-    	7 : -0.4,
-    	8 : -0.8,
-    	9 : -1.0,
-    	10 : -1.2,
-    	11 : -1.6,
-    	12 : -2.4 }
+		1 : -2.6,
+		2 : -2.4,
+		3 : -0.7,
+		4 : 0.8,
+		5 : 1.3,
+		6 : 0.8,
+		7 : -0.4,
+		8 : -0.8,
+		9 : -1.0,
+		10 : -1.2,
+		11 : -1.6,
+		12 : -2.4 }
 
 	adjustedCRtemp = pd.Series()
 	for row in range(air_data.shape[0]):
@@ -578,7 +577,7 @@ def genclimatefiles(whichbay, settings):
 		observedlake = usgs_ob.get_data(start_date = settings['spinup_date'] - dt.timedelta(days=1),
 								 		 end_date = settings['forecast_start'],
 										 locations = {"RL":'04295000'},
-                                          variables = getvars)
+										  variables = getvars)
 		# adjust height reference to 93 ft and convert to meters
 		observedlake['RL']['LAKEHT'] = (observedlake['RL']['LAKEHT']-93) * 0.3048
 		# store observed lake height in bay object for later concat with predicted height
@@ -662,7 +661,7 @@ def genclimatefiles(whichbay, settings):
 		forecastlake = usgs_ob.get_data(start_date = settings['forecast_start'],
 								 		end_date = adjusted_end_date,
 										locations = {"RL":'04295000'},
-                                        variables = getvars)
+										variables = getvars)
 		# adjust height reference to 93 ft and convert to meters
 		forecastlake['RL']['LAKEHT'] = (forecastlake['RL']['LAKEHT']-93) * 0.034478e-05
 		# store observed lake height in bay object for later concat with predicted height

--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -1411,7 +1411,8 @@ def gendatablockfile(theBay, settings):
 	# Calculate 1 hour in iterations
 	hourIter = int(86400 / AEM3D_DEL_T / 24)
 	# Calculate iteration for forecast start: Time between forecast date and spinup start
-	forecastStartIter = int((settings['forecast_start'] - (settings['spinup_date'] + dt.timedelta(days=1))).total_seconds() / AEM3D_DEL_T) + 1
+	# forecastStartIter = int((settings['forecast_start'] - (settings['spinup_date'] + dt.timedelta(days=1))).total_seconds() / AEM3D_DEL_T) + 1
+	forecastStartIter = int((settings['forecast_start'] - settings['spinup_date']).total_seconds() / AEM3D_DEL_T) + 1
 
 	logger.info(f'Configuring datablock.xml file')
 	generate_file_from_template('datablock.xml.template',

--- a/models/aem3d/waterquality.py
+++ b/models/aem3d/waterquality.py
@@ -257,13 +257,16 @@ def genwqfiles (theBay):
 
 		# I think it's appropriate to have this be hard-coded, as it shouldn't change... unless someone runs our workflow outside of the VACC
 		rf_models_dir = '/netfiles/ciroh/models/cq_randomforest_peterisles/current/'
+		# rf_models_dir = '/netfiles/ciroh/nbeckage/rfcq/'
+
+		print(f"Q DATAFRAME:")
+		print(Q)
 		# make wQ a settings, have peter's stuff be an option
 		if cqVersion == 'Clelia':
 			# Clelia TP Concentration - Discharge Relationship
 			#   Same for ALL ILS inputs!!
 			zTP = (flows['MS']['streamflow'] - 159.78) / 132.64
 			phosdf['TP'] =  ( 0.011001 * np.power(zTP,2) + 0.073104 * zTP + 0.091528 ) * p_redux
-			
 		elif cqVersion == 'islesRF':
 			rf_tp_dir = os.path.join(rf_models_dir, "TP")
 			Q_features = add_features(pd.DataFrame(Q))

--- a/models/islesRF/cqrf.py
+++ b/models/islesRF/cqrf.py
@@ -53,7 +53,7 @@ def to_metricQ(streamflow_dict, streamflow_colname='streamflow'):
 		metric_q_dfs[location] = metric_q_df
 	return metric_q_dfs
 
-def add_features(data, streamflow_colname='streamflow'):
+def add_features(data, streamflow_colname='streamflow (m³/s)'):
 	'''
 	Function to add features to a daily discharge dataframe for a USGS gauge. Features added are the same as those used by Isles, 2023 (https://doi.org/10.1016/j.watres.2023.120876)
 	Exact specifications for how features were engineered can be found in the code contained in the supplmentary material of said paper.


### PR DESCRIPTION
What started as a small bug-squashing branch ended up being a significant change to our streamflow processing `AEM3D_prep_IAM.py` ... go figure!

In this pull request:
- Change default name for streamflow series or dataframe column to include units (default name is `'streamflow (m³/s)'`)
- Correct the `forecastStartIter` calculations so that it does not unnecessarily subtract an extra day from the forecast start date
- Create new function, `backfillCaFlowsSpinup()`, to fill in instantaneous streamflow (iv) gaps with daily values (dv) for Canadian gauges (rock and pike). This function applies to the _spinup period only_*. 
- Create new function, `getdailyflows()`, similar in structure to `getflowfiles()`, that gets dv streamflow from CA and USGS gauges to provide data for CQ calculations in `waterquality.py`. For non-baseline scenarios (mem1 -6) that use NWM streamflow during the forecast period, daily averages are calculated from NWM flow, with timestamps set to 12:00 UTC. No time zone adjustments are implemented.

Closing un-rebased pull request #77, and deleting the [data_bug_fixes](https://github.com/CIROH-UVM/forecast-workflow/tree/data_bug_fixes) branch, as it is poorly named and many changes are lumped into too few commits. This branch/PR reflects those changes in a more organized fashion

*Changes of a data gap are less likely during the forecast period because it is shorter, but we might consider a similar solution to tackle the various data gaps during the forecast period that are causing some of our FEE runs to fail. Just food for thought.