### PR TITLE
Edits to backfillCaFlowsSpinup()

### DIFF
--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -136,6 +136,19 @@ def backfillCaFlowsSpinup(ca_data, settings):
 		missing_days = dv.index.difference(iv_dates)
 		# subset the daily data to be only the days that are missing form instantaneous data
 		dv_days = dv.loc[missing_days]
+		
+		# some logging messages to check my math... realized the index comparison was wrong before
+		print(f"\nSpinup period is {(forecast_start - spinup).days} days long")
+		print(f"There are {len(iv_dates)} dates with at least one instantaneous value in ca_data")
+		print(f"Therefore there should be {(forecast_start - spinup).days - len(iv_dates)} daily value dates injected")
+		print(f"In fact there were {len(dv_days)} dates injected")
+		if len(missing_days) + len(iv_dates) != (forecast_start - spinup).days:
+			warnings.warn("Faulty index comparison; number of missing dates plus exisiting dates does not add up to total timespan. Daily values could potentially have missing dates.", UserWarning)
+		print()
+
+		# option logger messages for debugging purposes 
+		# print("Daily values to be injected into instantaneous timeseries:")
+		# print(dv_days)
 		# No inherent time zone info to daily values
 		# so, reset tz to ET, set hour to Noon, convert tz to UTC
 		dv_days.index = dv_days.index.map(lambda t: t.replace(hour=12, tzinfo=pytz.timezone('America/New_York')).tz_convert(dt.UTC))

--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -102,17 +102,23 @@ def remove_nas(series):
 
 def backfillCaFlowsSpinup(ca_data, settings):
 	'''
-	Very specific function to fill in missing dates at the beginning of Canadian instantaneous data spinup series.
-	Fills missing dates with daily means taken from Canadian daily values service.
-	Only fills in dates that are completely missing from the instantaneous timerseries.
+	Fill in missing dates in the Canadian instantaneous data spinup series with daily values.
+	Only fills in dates that are completely missing from the instantaneous timerseries with daily means from Canadian daily values (dv) service.
+	Note that the nested ditionary ca_data is modified inplace.
+
+	Args:
+	-- ca_data (nested dict) [req]: instantaneous canadian streamflow timeseries in standard get_data() format
+	-- settings (dict) [req]: dictionary of run settings
+
+	Returns:
+	None; modifies ca_data inplace 
 	'''
 	ca_gauges = {"PK":'030424',"RK":'030425'}
-	spinup_date = settings['spinup_date']
 	for loc, iv_dict in ca_data.items():
 		first_date = iv_dict['streamflow'].index[0]
 		# only fill in missing dates if the data gap is at the BEGGINNING of the timeseries
 		# AEM3D can interpolate over middle gaps
-		if first_date > spinup_date.replace(tzinfo=dt.UTC):
+		if first_date > settings['spinup_date'].replace(tzinfo=dt.UTC):
 			print(f"First instantaneous value for {loc} is after spinup: {first_date}")
 			print(f"Backfilling {loc} IV streamflow with daily values...")
 			# getting daily data, for spinup period, for specific gauge

--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -37,6 +37,7 @@ import glob
 import os
 import datetime as dt
 import pytz
+import warnings
 
 AEM3D_DEL_T = 300
 


### PR DESCRIPTION
Previously this function only merged IV streamflow series with daily values IF the first date in the IV series came after the spinup date. Now, the function looks at every IV series and fills in any missing dates with daily values.

Other changes to note:
- Time zone adjustment: IV data, by the time it reaches this function, is in UTC time. Daily values have no time info, but the assumption is that the date lines are constructed in the local timezone of the gauge, ET. So, in order to have a valid date comparison, the IV indices are converted back into ET before the indices of each series are compared. Then, after the comparison is done, daily values are set to 12:00 ET, then converted to UTC. Note that the IV data is not explicitly set back to UTC in the code, but this is because the IV indices used for comparison are a copy and thus do not affect the index of the original IV series that is being merged. 
- Added some validation messages that ensure that there is at least one value for every date in the spinup period - which should be the case after merging