### PR TITLE
Fixes for FEE_v3

### DIFF
--- a/batch/debug/feeDebug.py
+++ b/batch/debug/feeDebug.py
@@ -1,0 +1,218 @@
+from collections import deque
+import datetime as dt
+import logging
+from models.aem3d.AEM3D import ordinalToDatetime
+import os
+import pandas as pd
+import warnings
+import xarray as xr
+
+'''
+This purpose of this script is to Loop through some FEE runs (specififed by the paramters below) and report any failed runs.
+If a failed run is detected, the error is diagnosed and reported. This script creates two files by default; (1) a comprehensive log file that
+reports error messages detected in failed runs, and (2) a concise csv summary file of failed runs and their causes.
+'''
+
+def aem3d_fatal(fatal_msg):
+	'''
+    Function that parses error messages from AEM3D model runs, identifying fatal errors and extracting relevant details.
+
+    Args:
+    -- fatal_msg (list) [req]: A list of strings representing the error message lines from the AEM3D model output.
+
+    Returns:
+    -- err_report (dict): A dictionary containing details of the error with the following keys:
+        - 'error' (str): Always set to 'aem3d_fatal'.
+        - 'err_type' (str or None): The type of fatal error identified (e.g., "Insufficient data", "run_aem3d.dat missing"). Extend this function to parse more AEM3D error types as they come up.
+        - 'file' (str or None): The file involved in the error (if applicable).
+        - 'last_date_ord' (str or None): The last date in ordinal form before the error occurred (if applicable).
+        - 'last_date_dt' (str or None): The last date in human-readable datetime format before the error occurred (if applicable).
+    '''
+	err_report = {'error':'aem3d_fatal', 'err_type':None, 'file':None, 'last_date_ord':None, 'last_date_dt':None}
+	for i, line in enumerate(fatal_msg):
+		print(f'\t\t\t\t {line}')
+		# add more if clauses to deal with other AEM3D fatal error types as they come up
+		if "Insufficient data" in line:
+			err_report['err_type'] = "Insufficient data"
+			err_report['file'] = line.split('file ')[-1]
+			ord_date = fatal_msg[i+1].split('read: ')[-1].split(' ')[0]
+			err_report['last_date_ord'] = ord_date
+			err_report['last_date_dt'] = ordinalToDatetime(ord_date).strftime("%m/%d/%Y")
+			# print(err_report)
+		elif "run_aem3d.dat missing" in line:
+			err_report['err_type'] = "run_aem3d.dat missing"
+			err_report['file'] = "run_aem3d.dat"
+	return err_report
+
+def get_timestamps(ds):
+	'''
+	Function that pulls the timestamps out of an "aem3d-run/outfiles/nc/sheet_surface_forecast.nc" file.
+	May work for other AEM3D netcdf output files if they are structured similariliy to the surface sheets.
+
+	Args:
+	-- ds (xarray.Dataset) [req]: the dataset to get timestamps for
+
+	Returns:
+	-- timestamps (list): a list of datetime objects representing the timestamps of the netcdf file
+	'''
+	timestamps = []
+	for i in range(len(ds.T)):
+		ts = dt.datetime(year=int(ds['Year'].values[i]),
+						month=int(ds['Month'].values[i]),
+						day=int(ds['Day'].values[i]),
+						hour=int(ds['Hour'].values[i]),
+						minute=int(ds['Minute'].values[i]),
+						second=int(ds['Second'].values[i]))
+		timestamps.append(ts)
+	return timestamps
+
+def parse_failed_run(filelines):
+	'''
+    Function that parses the lines of the .out file to detect what kind of error caused the run to fail.
+	Passes on the .out file lines to more specific error parser functions once a braod kind of error is determined
+
+    Args:
+    -- filelines (list) [req]: A list of strings representing the lines of the .out file from a workflow run.
+
+    Returns:
+    -- report (dict or None): A dictionary containing the parsed fatal error report if a fatal error is found, or None
+    	if no fatal error is detected. The structure of the report is the same as the output of the aem3d_fatal() function.
+    '''
+	for i, line in enumerate(filelines):
+		# check if AEM3D threw a fatal error
+		if "***** FATAL ERROR ****" in line:
+			fatal_error = [line.rstrip(' \n') for line in filelines[i:i+9] if line != '\n']
+			report = aem3d_fatal(fatal_error)
+			return report
+
+def report_df(failure_dict):
+	'''
+    Function that converts a nested dictionary of failure data into a formatted pandas DataFrame. The DataFrame is structured
+    by extracting key components and organizing fields for easier analysis and reporting.
+
+    Args:
+    -- failure_dict (dict) [req]: A nested dictionary containing failure data, where keys are hierarchical strings
+       (e.g., 'cq_paradigm.scenario.year.date.field') and values are the corresponding data.
+
+    Returns:
+    -- df (pandas.DataFrame): A pandas DataFrame indexed by 'cq_paradigm', 'scenario', 'year', and 'date' with
+       the fields 'error', 'err_type', 'file', 'last_date_ord', and 'last_date_dt' as columns.
+    '''
+	# Use pandas json_normalize to flatten the dictionary
+	df = pd.json_normalize(failure_dict, sep='.')
+	# Transpose the DataFrame so that the keys form the columns
+	df = df.T.reset_index()
+	# Split the flattened keys into individual components
+	df[['cq_paradigm', 'scenario', 'year', 'date', 'field']] = df['index'].str.split('.', expand=True)
+	# Drop the old 'index' column
+	df = df.drop(columns=['index'])
+	# Rearrange the DataFrame for better readability
+	df = df[['cq_paradigm', 'scenario', 'year', 'date', 'field', 0]]
+	# Rename the last column to 'value'
+	df.columns = ['cq_paradigm', 'scenario', 'year', 'date', 'Field', 'Value']
+	# Pivot the DataFrame to have one row per 'Year' and 'Date', and fields as columns
+	df = df.pivot_table(index=['cq_paradigm', 'scenario','year', 'date'], columns='Field', values='Value', aggfunc='first').reset_index()
+	df.columns.name = None
+	# set the new multi-index
+	df = df.set_index(['cq_paradigm', 'scenario', 'year', 'date'])
+	order = ['error', 'err_type', 'file', 'last_date_ord', 'last_date_dt']
+	df = df[order]
+
+	return df
+
+##### DEBUG PARAMTERS #####
+fee_version = 3
+# cq_paradigms = ['calibratedCQ', 'randomForestCQ']
+cq_paradigms = ['randomForestCQ']
+# dir_years = ['2019', '2020', '2021', '2022','2023']
+dir_years = ['2023']
+# scenarios = ['baseline', 'mem1', 'mem2', 'mem3', 'mem4', 'mem5', 'mem6']
+scenarios = ['baseline', 'mem3']
+launch_start = '0601'
+launch_end = '1031'
+file_path = "*.out"
+# NOTE: last 150 lines should
+last_lines_to_read = 150
+# provide a custom log name
+log_name = 'rf2023BlM3.log'
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,           # Log level (DEBUG, INFO, WARNING, ERROR, CRITICAL)
+    format='%(asctime)s - %(levelname)s - %(message)s'  # Log format
+)
+
+logger = logging.getLogger()
+logger.addHandler(logging.FileHandler(log_name, 'w'))
+print = logger.info
+
+def main():
+	# define the root fee dir
+	fee_dir = f"/netfiles/ciroh/7dayHABsHindcast/FEE_v{fee_version}"
+
+	# determine the error message to use based on fee version
+	# NOTE: prior to v3, there was no universal failed run message, but the most common failure was an AEM3D one
+	if fee_version < 3:
+		common_error_msg = 'Exception: AEM3D failure.'
+	else: common_error_msg = 'ERROR: RUN FAILED'
+
+	# Print the debug parameters
+	print(f"##### DEBUG PARAMETERS #####")
+	print(f"ROOT DIR: {fee_dir}")
+	print(f"CQ PARADIGMs: {cq_paradigms}")
+	print(f"SCENARIOS: {scenarios}")
+	print(f"YEARS: {dir_years}")
+	print(f"FIRST DATE: {launch_start}")
+	print(f"LAST DATE: {launch_end}\n")
+
+	fail_dict = {}
+
+	for cq in cq_paradigms:
+		print(f"CURRENT CQ PARADIGM: {cq}")
+		fail_dict[cq] = {}
+		for scen in scenarios:
+			print(f"\t SCENARIO: {scen}")
+			fail_dict[cq][scen] = {}
+			for dr_yr in dir_years:
+				print(f"\t\t YEAR: {dr_yr}")
+				fail_dict[cq][scen][dr_yr] = {}
+				launch_start_date = dt.datetime.strptime(launch_start, "%m%d").replace(year=int(dr_yr))
+				launch_end_date = dt.datetime.strptime(launch_end, "%m%d").replace(year=int(dr_yr))
+				# print(launch_start_date)
+				date_range = [launch_start_date + dt.timedelta(days=x) for x in range((launch_end_date - launch_start_date).days + 1)]
+				# manually selecting some dates to investigate, instead of entire date range (defined above)
+				failed_dates = []
+				for date in date_range:
+					# fail_dict[cq][scen][dr_yr][date.strftime("%Y%m%d")] = None
+					run_dir = os.path.join(fee_dir, cq, scen, dr_yr, date.strftime("%Y%m%d"))
+
+					# list the directory and filter to get just the outfile
+					outfile = [f for f in os.listdir(run_dir) if f.endswith(".out")]
+					# the list above should have a length of exactly 1 (there should be one outfile)
+					# raise a warning if for some reason ther is more than 1 outfile
+					if len(outfile) != 1:
+						warnings.warn(f"Multiple outfiles detected: {outfile}")
+					outfile = outfile[0]
+
+					# create full file path
+					full_out_path = os.path.join(run_dir, outfile)
+					# print(full_out_path)
+					# open file and read the lines at the end of the file
+					with open(full_out_path, 'r') as file:
+						lastlines = list(deque(file, maxlen=last_lines_to_read))
+					if lastlines[-1].rstrip('\n') == common_error_msg:
+						print(f"\t\t\t DATE: {date.strftime('%m/%d/%Y')}")
+						print(f"\t\t\t PATH: {run_dir}")
+						error_report = parse_failed_run(lastlines)
+						# failed_dates.append(date.strftime('%Y%m%d'))
+						# print(error_report)
+						fail_dict[cq][scen][dr_yr][date.strftime('%Y%m%d')] = error_report
+					# # optional message
+					# else: print("\t\t\t\t No run failure detected")
+
+	# generate the concise report table
+	report = report_df(fail_dict)
+	report.to_csv('err_report.csv')
+
+if __name__ == '__main__':
+	main()

--- a/batch/debug/feeDebug.py
+++ b/batch/debug/feeDebug.py
@@ -13,7 +13,7 @@ If a failed run is detected, the error is diagnosed and reported. This script cr
 reports error messages detected in failed runs, and (2) a concise csv summary file of failed runs and their causes.
 '''
 
-def aem3d_fatal(fatal_msg):
+def aem3d_fatal(fatal_msg, err_report):
 	'''
     Function that parses error messages from AEM3D model runs, identifying fatal errors and extracting relevant details.
 
@@ -28,7 +28,7 @@ def aem3d_fatal(fatal_msg):
         - 'last_date_ord' (str or None): The last date in ordinal form before the error occurred (if applicable).
         - 'last_date_dt' (str or None): The last date in human-readable datetime format before the error occurred (if applicable).
     '''
-	err_report = {'error':'aem3d_fatal', 'err_type':None, 'file':None, 'last_date_ord':None, 'last_date_dt':None}
+	err_report['error'] = 'aem3d_fatal'
 	for i, line in enumerate(fatal_msg):
 		print(f'\t\t\t\t {line}')
 		# add more if clauses to deal with other AEM3D fatal error types as they come up
@@ -66,7 +66,16 @@ def get_timestamps(ds):
 		timestamps.append(ts)
 	return timestamps
 
-def parse_failed_run(filelines):
+def prep_IAM_err(prep_err, err_report):
+	err_report['error'] = 'prep_IAM'
+	prnt = False
+	for i, line in enumerate(prep_err):
+		if "During handling of the above exception" in line: prnt = True
+		if prnt: print(f'\t\t\t\t {line}')
+		if "AEM3D_prep_worker - None" in line: prnt = False
+	return err_report
+
+def parse_failed_run(filelines, report):
 	'''
     Function that parses the lines of the .out file to detect what kind of error caused the run to fail.
 	Passes on the .out file lines to more specific error parser functions once a braod kind of error is determined
@@ -78,12 +87,19 @@ def parse_failed_run(filelines):
     -- report (dict or None): A dictionary containing the parsed fatal error report if a fatal error is found, or None
     	if no fatal error is detected. The structure of the report is the same as the output of the aem3d_fatal() function.
     '''
+	# for line in filelines:
+	# 	print(line)
 	for i, line in enumerate(filelines):
 		# check if AEM3D threw a fatal error
 		if "***** FATAL ERROR ****" in line:
 			fatal_error = [line.rstrip(' \n') for line in filelines[i:i+9] if line != '\n']
-			report = aem3d_fatal(fatal_error)
-			return report
+			report = aem3d_fatal(fatal_error, report)
+			break
+		if "AEM3D_prep_IAM.py failed." in line:
+			prep_error = [line.rstrip(' \n') for line in filelines[i:] if line != '\n']
+			report = prep_IAM_err(prep_error, report)
+			break
+	return report
 
 def report_df(failure_dict):
 	'''
@@ -134,7 +150,7 @@ file_path = "*.out"
 # NOTE: last 150 lines should
 last_lines_to_read = 150
 # provide a custom log name
-log_name = 'rf2023BlM3.log'
+log_name = 'rf2023BLM3'
 
 # Configure logging
 logging.basicConfig(
@@ -143,7 +159,7 @@ logging.basicConfig(
 )
 
 logger = logging.getLogger()
-logger.addHandler(logging.FileHandler(log_name, 'w'))
+logger.addHandler(logging.FileHandler(f'{log_name}.log', 'w'))
 print = logger.info
 
 def main():
@@ -180,8 +196,6 @@ def main():
 				launch_end_date = dt.datetime.strptime(launch_end, "%m%d").replace(year=int(dr_yr))
 				# print(launch_start_date)
 				date_range = [launch_start_date + dt.timedelta(days=x) for x in range((launch_end_date - launch_start_date).days + 1)]
-				# manually selecting some dates to investigate, instead of entire date range (defined above)
-				failed_dates = []
 				for date in date_range:
 					# fail_dict[cq][scen][dr_yr][date.strftime("%Y%m%d")] = None
 					run_dir = os.path.join(fee_dir, cq, scen, dr_yr, date.strftime("%Y%m%d"))
@@ -200,11 +214,13 @@ def main():
 					# open file and read the lines at the end of the file
 					with open(full_out_path, 'r') as file:
 						lastlines = list(deque(file, maxlen=last_lines_to_read))
+
 					if lastlines[-1].rstrip('\n') == common_error_msg:
 						print(f"\t\t\t DATE: {date.strftime('%m/%d/%Y')}")
-						print(f"\t\t\t PATH: {run_dir}")
-						error_report = parse_failed_run(lastlines)
-						# failed_dates.append(date.strftime('%Y%m%d'))
+						print(f"\t\t\t PATH: {full_out_path}")
+						error_report = {'error':'run_failure', 'err_type':'unkown', 'file':outfile, 'last_date_ord':-1, 'last_date_dt':-1}
+						# print("\nPASSING TO PARSE_FAILED_RUNS\n")
+						error_report = parse_failed_run(lastlines, error_report)
 						# print(error_report)
 						fail_dict[cq][scen][dr_yr][date.strftime('%Y%m%d')] = error_report
 					# # optional message
@@ -212,7 +228,9 @@ def main():
 
 	# generate the concise report table
 	report = report_df(fail_dict)
-	report.to_csv('err_report.csv')
+	report.to_csv(f'{log_name}.csv')
+
+	print("DEBUG SCRIPT COMPLETE")
 
 if __name__ == '__main__':
 	main()

--- a/batch/launchExperiment.py
+++ b/batch/launchExperiment.py
@@ -24,7 +24,7 @@ with open(experiment_conf_file) as experiment_config:
 config = get_args.load_defaults()
 
 # load in the default job script template
-with open('/netfiles/ciroh/7dayHABsHindcast/submitTEMPLATE.sh') as f:
+with open('/users/n/b/nbeckage/ciroh/forecast-workflow/batch/submitTEMPLATE.sh') as f:
 	src = Template(f.read())
 
 ### 6/11/24 - I think this is outdated - orig will be the scenario dir (same dir as experiemnt_config)
@@ -74,9 +74,12 @@ for year in years:
 		with open('submit.sh', 'w') as submit_script:
 			submit_script.write(job_script)
 
-		print(scenario_dir_date)
+		print(f"Launching run in: {scenario_dir_date}")
+		sys.stdout.flush()
 		# Uncomment to submit
 		subprocess.run(['sbatch ' 'submit.sh'], shell=True)
 		# wait so as to not overwhelm the VACC with GFS / NWM file reads for AEM3D_prep_IAM
 		time.sleep(30)
 os.chdir(orig)
+
+print("Experiment Launch Complete.")

--- a/batch/launchScenarioTEMPLATE.sh
+++ b/batch/launchScenarioTEMPLATE.sh
@@ -12,10 +12,15 @@
 
 source /users/n/b/nbeckage/miniconda3/etc/profile.d/conda.sh
 # source /users/p/c/pclemins/usr/local/miniforge3/etc/profile.d/conda.sh
+
 conda activate forecast
 
+# parse cq dir (1st arg) scenario dir (2nd arg)
+CQ_DIR=$1
+SCENARIO_DIR=$2
+
 # change to whatever directory you want to put your scenario runs in
-cd /netfiles/ciroh/7dayHABsHindcast/<FEE_VERSION>/<CQ_PARADIGM>/<SCENARIO_DIR>/
+cd /netfiles/ciroh/7dayHABsHindcast/<FEE_VERSION>/$CQ_DIR/$SCENARIO_DIR/
 
 # note that you must have an experiment-specific configuration file in your scenario directory
-python ../../launchExperiment.py experiment_config.json
+python /users/n/b/nbeckage/ciroh/forecast-workflow/batch/launchExperiment.py experiment_config.json

--- a/batch/submitTEMPLATE.sh
+++ b/batch/submitTEMPLATE.sh
@@ -10,11 +10,22 @@
 #SBATCH --output=%x_%j.out
 #SBATCH --mail-type=FAIL
 
-set -x
+set -xe
+
+# Function to print error message on failure
+failed_run() {
+    echo "ERROR: RUN FAILED"
+}
+
+# Trap the ERR signal to call the error handler when a command fails
+trap failed_run ERR
 
 # source /users/p/c/pclemins/usr/local/miniforge3/etc/profile.d/conda.sh
 source /users/n/b/nbeckage/miniconda3/etc/profile.d/conda.sh
+
+# activate forecast environment
 conda activate forecast
+
 # export PYTHONPATH=/users/p/c/pclemins/repos/forecast-workflow
 export PYTHONPATH=/users/n/b/nbeckage/ciroh/forecast-workflow
 

--- a/data/usgs_ob.py
+++ b/data/usgs_ob.py
@@ -57,12 +57,12 @@ def USGSgetvars_function(id, variables, start, end, service='iv'):
 			try:
 				returnValue = gage.json()
 				values = gage.json()['value']['timeSeries'][0]['values'][0]['value']
+				# get the units for the var from the API
+				unit = gage.json()['value']['timeSeries'][0]['variable']['unit']['unitCode']
 			except:
 				if returnValue is None:
 					print("USGS Observational Hydrology Data Request Failed... Will retry")
 				else: raise ValueError(f"Bad request... ensure the data you are requesting is available from station: {id}")
-			# get the units for the var from the API
-			unit = gage.json()['value']['timeSeries'][0]['variable']['unit']['unitCode']
 		var_name = f'{var} ({unit})'
 
 		df = pd.DataFrame(values)

--- a/models/aem3d/AEM3D.py
+++ b/models/aem3d/AEM3D.py
@@ -16,5 +16,23 @@ def datetimeToOrdinal(date):
 	ordinaldate = yearday + str(fracsec)[1:6].ljust(5,'0')  # add the percentage seconds since noon
 	return ordinaldate
 
+def ordinalToDatetime(ordinaldate):
+    # Split the ordinal date into year, day of year, and fraction of the day
+    year = int(ordinaldate[:4])  # First 4 characters are the year
+    day_of_year = int(ordinaldate[4:7])  # Next 3 characters are the day of the year
+    fraction_of_day = float('0' + ordinaldate[7:])  # Remaining part is the fraction of the day
+
+    # Convert year and day of year into a date
+    base_date = dt.datetime(year, 1, 1) + dt.timedelta(days=day_of_year - 1)
+
+    # Calculate total seconds in the day and multiply by the fraction of the day
+    total_seconds_in_day = 86400  # 24 * 3600 seconds in a day
+    seconds_since_midnight = fraction_of_day * total_seconds_in_day
+
+    # Add the seconds to the base_date
+    final_datetime = base_date + dt.timedelta(seconds=seconds_since_midnight)
+
+    return final_datetime
+
 def index_to_ordinal_date(pandas_data):
 	return pandas_data.rename(index=datetimeToOrdinal)

--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -1556,7 +1556,8 @@ def gencntlfile(theBay, settings):
 	
 
 	# Calculate iterations: Time between forecast end and start of sim
-	### NOTE: adding 12 to iterations so that the last forecast timestamp is 6/8 00:00 instead of 6/7 23:00 (given forecast start is 6/1 00:00). Not sure why 12 works...
+	### NOTE: adding 12 to iterations so that the last forecast timestamp is 6/8 00:00 instead of 6/7 23:00 (given forecast start is 6/1 00:00)\
+	### each AEM3D iteration is 5 minutes, so 12 iterations is an hour, which is how long we want to extend the forecast to get to a full 7 days
 	iterations = int((settings['forecast_end'] - simstart).total_seconds() / AEM3D_DEL_T) + 12
 	logger.info(f'Configuring AEM3D to run {iterations} iterations')
 

--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -871,7 +871,7 @@ def genclimatefiles(whichbay, settings):
 										locations = {"RL":'04295000'},
 										variables = getvars)
 		# adjust height reference to 93 ft and convert to meters
-		forecastlake['RL']['LAKEHT'] = (forecastlake['RL']['LAKEHT']-93) * 0.034478e-05
+		forecastlake['RL']['LAKEHT'] = (forecastlake['RL']['LAKEHT']-93) * 0.3048
 		# store observed lake height in bay object for later concat with predicted height
 		forecastClimate['300'] = forecastlake['RL']
 
@@ -1556,7 +1556,8 @@ def gencntlfile(theBay, settings):
 	
 
 	# Calculate iterations: Time between forecast end and start of sim
-	iterations = int((settings['forecast_end'] - simstart).total_seconds() / AEM3D_DEL_T)
+	### NOTE: adding 12 to iterations so that the last forecast timestamp is 6/8 00:00 instead of 6/7 23:00 (given forecast start is 6/1 00:00). Not sure why 12 works...
+	iterations = int((settings['forecast_end'] - simstart).total_seconds() / AEM3D_DEL_T) + 12
 	logger.info(f'Configuring AEM3D to run {iterations} iterations')
 
 

--- a/models/aem3d/AEM3D_prep_worker.py
+++ b/models/aem3d/AEM3D_prep_worker.py
@@ -36,7 +36,8 @@ def main():
 
     # These two settings return datetime objs set to midnight already
     THEBAY.FirstDate = datetimeToOrdinal(SETTINGS['spinup_date'])
-    THEBAY.LastDate = datetimeToOrdinal(SETTINGS['forecast_end'])
+    # adding a two hour nudge to the last date b/c we want the AEM3D to create data for the forecast end date at midnight
+    THEBAY.LastDate = datetimeToOrdinal(SETTINGS['forecast_end'] + dt.timedelta(hours=2))
 
 
     ## Need dataframes for hydrology from Missisquoi, Mill, JewittStevens

--- a/models/aem3d/get_args.py
+++ b/models/aem3d/get_args.py
@@ -52,7 +52,7 @@ def check_values(settings_dict, defaults=False):
 	if not 0 <= settings_dict['blending_ratio'] <= 1.0:
 		raise ValueError(f"'{settings_dict['blending_ratio']}' is not a valid blending ratio; must be between 0 and 1.")
 	
-	print("Settings to be checked ", settings_dict)
+	# print("Settings to be checked ", settings_dict)
 
 	valid_datasets = {'wdo':["NOAA_LCD+FEMC_CR"],
 				   	  'wdf':["NOAA_LCD+FEMC_CR", "NOAA_GFS"],


### PR DESCRIPTION
An assortment of tweaks and changes to get the workflow to run correctly for version 3. Also created a new debug script. Changes include:
- improve interoperability of `batch/` scripts; now, the only file you need to copy/paste into the FEE dir (`FEE_v3/`, etc) is launchScenarioTEMPLATE.sh.
- tweak `theBay.LastDate` and `iterations` so that AEM3D produces an even 7 days worth of timestamps
- have usgs_ob.py infer units from USGS API call
- create a new debug script to assess a FEE suite of runs for fatal errors, and report the cause of said error