### PR TITLE
Minor improvements to batch protocols

### DIFF
--- a/batch/debug/debug_params.json
+++ b/batch/debug/debug_params.json
@@ -1,0 +1,11 @@
+{
+	"root_dir": "/netfiles/ciroh/<hindcast_dir>/",
+	"cq_paradigms": ["randomForestCQ"],
+	"dir_years": ["2023"],
+	"scenarios": ["baseline", "mem3"],
+	"launch_start": "0601",
+	"launch_end": "1031",
+	"file_path": "*.out",
+	"last_lines_to_read": 150,
+	"log_name": "rf2023BLM3"
+}

--- a/batch/debug/feeDebug.py
+++ b/batch/debug/feeDebug.py
@@ -140,7 +140,7 @@ def report_df(failure_dict):
 	return df
 
 ##### DEBUG PARAMTERS #####
-fee_version = 3
+root_dir = "/netfiles/ciroh/<hindcast_dir>/"
 # cq_paradigms = ['calibratedCQ', 'randomForestCQ']
 cq_paradigms = ['randomForestCQ']
 # dir_years = ['2019', '2020', '2021', '2022','2023']
@@ -166,18 +166,14 @@ logger.addHandler(logging.FileHandler(f'{log_name}.log', 'w'))
 print = logger.info
 
 def main():
-	# define the root fee dir
-	fee_dir = f"/netfiles/ciroh/7dayHABsHindcast/FEE_v{fee_version}"
-
 	# determine the error message to use based on fee version
 	# NOTE: prior to v3, there was no universal failed run message, but the most common failure was an AEM3D one
-	if fee_version < 3:
-		common_error_msg = 'Exception: AEM3D failure.'
-	else: common_error_msg = 'ERROR: RUN FAILED'
+	# common_error_msg = 'Exception: AEM3D failure.'
+	common_error_msg = 'ERROR: RUN FAILED'
 
 	# Print the debug parameters
 	print(f"##### DEBUG PARAMETERS #####")
-	print(f"ROOT DIR: {fee_dir}")
+	print(f"ROOT DIR: {root_dir}")
 	print(f"CQ PARADIGMs: {cq_paradigms}")
 	print(f"SCENARIOS: {scenarios}")
 	print(f"YEARS: {dir_years}")
@@ -201,7 +197,7 @@ def main():
 				date_range = [launch_start_date + dt.timedelta(days=x) for x in range((launch_end_date - launch_start_date).days + 1)]
 				for date in date_range:
 					# fail_dict[cq][scen][dr_yr][date.strftime("%Y%m%d")] = None
-					run_dir = os.path.join(fee_dir, cq, scen, dr_yr, date.strftime("%Y%m%d"))
+					run_dir = os.path.join(root_dir, cq, scen, dr_yr, date.strftime("%Y%m%d"))
 
 					# list the directory and filter to get just the outfile
 					outfile = [f for f in os.listdir(run_dir) if f.endswith(".out")]

--- a/batch/experiment_configTEMPLATE.json
+++ b/batch/experiment_configTEMPLATE.json
@@ -11,7 +11,7 @@
 	"hydrology_dataset_observed" : "USGS_IV",
 	"hydrology_dataset_forecast" : "NOAA_NWM_PROD",
 	"nwm_forecast_member" : "<nwm_forecast_member>",
-	"data_dir" : "/netfiles/ciroh/7dayHABsHindcast/hindcastData/",
-	"aem3d_command_path" : "<path_to_aem3d>",
+	"data_dir" : "/netfiles/ciroh/hindcastData/",
+	"aem3d_command_path" : "/users/n/b/nbeckage/ciroh/aem3d-1.1.2-535/aem3d_openmp.exe",
 	"cqVersion" : "<cqVersion>"
 }

--- a/batch/launchExperiment.py
+++ b/batch/launchExperiment.py
@@ -49,6 +49,17 @@ for year in years:
 	delta = end_dt - start_dt
 	scenario_dir_year = os.path.join(orig, f'{year}/')
 	dates = [start_dt + dt.timedelta(days=d) for d in range(delta.days+1)]
+	# Optionally, manually choose dates (for testing, mainly)
+	# dates = [dt.datetime(int(year), 5, 5),
+	# 		 dt.datetime(int(year), 5, 26),
+	# 		 dt.datetime(int(year), 6, 5),
+	# 		 dt.datetime(int(year), 6, 26),
+	# 		 dt.datetime(int(year), 7, 5),
+	# 		 dt.datetime(int(year), 7, 26),
+	# 		 dt.datetime(int(year), 8, 5),
+	# 		 dt.datetime(int(year), 8, 26),
+	# 		 dt.datetime(int(year), 9, 5),
+	# 		 dt.datetime(int(year), 9, 26)]
 	spinup_month_and_day = dt.datetime.strptime(experiment_launch_params['spinup_date'], "%m%d")
 	# get the length of the forecast in days (7 days, 30, etc)
 	forecast_days = int(experiment_launch_params['forecast_days'])

--- a/batch/launchExperiment.py
+++ b/batch/launchExperiment.py
@@ -20,6 +20,16 @@ experiment_conf_file = sys.argv[1]
 with open(experiment_conf_file) as experiment_config:
 	experiment_launch_params = json.load(experiment_config)
 
+# parse start and end year args from command line if passed
+try:
+	start_year = int(sys.argv[2])
+except IndexError:
+	start_year = int(experiment_launch_params['start_year'])
+try:
+	end_year = int(sys.argv[3])
+except IndexError:
+	end_year = int(experiment_launch_params['end_year'])
+
 # load in the default run config file
 config = get_args.load_defaults()
 
@@ -31,7 +41,7 @@ with open('/users/n/b/nbeckage/ciroh/forecast-workflow/batch/submitTEMPLATE.sh')
 # root_dir = '/netfiles/ciroh/7dayHABsHindcast/'
 # scenario_dir = os.path.join(root_dir, f"{experiment_launch_params['scenario']}/")
 
-years = list(reversed([str(y) for y in range(int(experiment_launch_params['end_year']), int(experiment_launch_params['start_year'])+1)]))
+years = list(reversed([str(y) for y in range(end_year, start_year+1)]))
 
 for year in years:
 	start_dt = dt.datetime.strptime(year+experiment_launch_params['start_date'], '%Y%m%d')

--- a/batch/launchScenarioTEMPLATE.sh
+++ b/batch/launchScenarioTEMPLATE.sh
@@ -15,12 +15,13 @@ source /users/n/b/nbeckage/miniconda3/etc/profile.d/conda.sh
 
 conda activate forecast
 
-# parse cq dir (1st arg) scenario dir (2nd arg)
-CQ_DIR=$1
-SCENARIO_DIR=$2
+# parse scenario dir, start year, end year
+SCENARIO_DIR=$1
+START_YEAR=$2
+END_YEAR=$3
 
 # change to whatever directory you want to put your scenario runs in
-cd /netfiles/ciroh/7dayHABsHindcast/<FEE_VERSION>/$CQ_DIR/$SCENARIO_DIR/
+cd /netfiles/ciroh/<hindcast_dir>/<cq_dir>/$SCENARIO_DIR/
 
 # note that you must have an experiment-specific configuration file in your scenario directory
-python /users/n/b/nbeckage/ciroh/forecast-workflow/batch/launchExperiment.py experiment_config.json
+python /users/n/b/nbeckage/ciroh/forecast-workflow/batch/launchExperiment.py experiment_config.json $START_YEAR $END_YEAR

--- a/default_settings.json
+++ b/default_settings.json
@@ -16,7 +16,7 @@
 	"nwm_forecast_member" : "medium_range_mem1",
 	"csv" : false,
 	"data_dir" : "/netfiles/ciroh/7dayHABsHindcast/hindcastData/",
-	"aem3d_input_dir" : "/netfiles/ciroh/models/aem3d/v5-20240518/AEM3D-inputs",
+	"aem3d_input_dir" : "/netfiles/ciroh/models/aem3d/current/AEM3D-inputs",
 	"aem3d_command_path" : "/usr/local/aem3d-1.1.2-535/aem3d_openmp.exe",
 	"cqVersion" : "202406Calibration"
 }


### PR DESCRIPTION
A few improvements I made since last time to make launching and debugging batches of runs a bit easier:
- Remove unnecessary harcoded directories that previously had to be manually edited 
- Add a start and end year command-line arg to `laucnhScenario.sh` that overrides whatever's in the `experiment_config` file
- Make the settings for the `feeDebug` script configurable, add an 'all' option to analyze all scenarios and years rather than having to write them all out in a list