### PR TITLE
Ensure model cycle selection and alignment for Rakhshinda's additional hindcast scenarios

### DIFF
--- a/batch/debug/debug_params.json
+++ b/batch/debug/debug_params.json
@@ -5,6 +5,7 @@
 	"scenarios": ["baseline", "mem3"],
 	"launch_start": "0601",
 	"launch_end": "1031",
+	"model_cycle": "00",
 	"file_string": "*.out",
 	"last_lines_to_read": 150,
 	"log_name": "rf2023BLM3",

--- a/batch/debug/feeDebug.py
+++ b/batch/debug/feeDebug.py
@@ -214,6 +214,7 @@ def main():
 	scenarios = debug_params["scenarios"]
 	launch_start = debug_params["launch_start"]
 	launch_end = debug_params["launch_end"]
+	model_cycle = debug_params["model_cycle"]
 	file_string = debug_params["file_string"]
 	last_lines_to_read = debug_params["last_lines_to_read"]
 	log_name = debug_params["log_name"]
@@ -232,7 +233,8 @@ def main():
 	log_print(f"SCENARIOS: {scenarios}")
 	log_print(f"YEARS: {dir_years}")
 	log_print(f"FIRST DATE: {launch_start}")
-	log_print(f"LAST DATE: {launch_end}\n")
+	log_print(f"LAST DATE: {launch_end}")
+	log_print(f"MODEL CYCLE: {model_cycle}\n")
 
 	fail_dict = {}
 
@@ -254,7 +256,7 @@ def main():
 			for dr_yr in dir_years_list:
 				log_print(f"\t\t YEAR: {dr_yr}")
 				fail_dict[cq][scen][dr_yr] = {}
-				launch_start_date = dt.datetime.strptime(launch_start, "%m%d%H").replace(year=int(dr_yr))
+				launch_start_date = dt.datetime.strptime(launch_start, "%m%d").replace(year=int(dr_yr), hour=int(model_cycle))
 				launch_end_date = dt.datetime.strptime(launch_end, "%m%d").replace(year=int(dr_yr))
 				# log_print(launch_start_date)
 				date_range = [launch_start_date + dt.timedelta(days=x) for x in range((launch_end_date - launch_start_date).days + 1)]

--- a/batch/launchExperiment.py
+++ b/batch/launchExperiment.py
@@ -57,7 +57,7 @@ else: years = [str(y) for y in range(start_year, end_year+1)]
 
 for year in years:
 	start_dt = dt.datetime.strptime(year+experiment_launch_params['start_date'], '%Y%m%d%H')
-	end_dt = dt.datetime.strptime(year+experiment_launch_params['end_date'], '%Y%m%d')
+	end_dt = dt.datetime.strptime(year+experiment_launch_params['end_date'], '%Y%m%d%H')
 	delta = end_dt - start_dt
 	scenario_dir_year = os.path.join(orig, f'{year}/')
 	dates = [start_dt + dt.timedelta(days=d) for d in range(delta.days+1)]
@@ -77,7 +77,7 @@ for year in years:
 		
 		config['spinup_date'] = dt.datetime(date.year, spinup_month_and_day.month, spinup_month_and_day.day).strftime('%Y%m%d')
 		config['forecast_start'] = date.strftime('%Y%m%d%H')
-		config['forecast_end'] = (date + dt.timedelta(days=forecast_days)).strftime('%Y%m%d')
+		config['forecast_end'] = (date + dt.timedelta(days=forecast_days)).strftime('%Y%m%d%H')
 		config['data_dir'] = experiment_launch_params['data_dir']
 		config['weather_dataset_spinup'] = experiment_launch_params['weather_dataset_spinup']
 		config['weather_dataset_forecast'] = experiment_launch_params['weather_dataset_forecast']

--- a/data/utils.py
+++ b/data/utils.py
@@ -306,7 +306,7 @@ def generate_hours_list(num_hours, source, forecast_type='medium', archive=False
 
 	Args:
 	-- num_hours (int) [req]: how many hours of forecast data you want.
-	-- saource (str) [req]: string indicating the forecast source. Valid values are 'gfs', 'nwm', and 'archive'.
+	-- source (str) [req]: string indicating the forecast source. Valid values are 'gfs', 'nwm', and 'archive'.
 	-- forecast_type (str) [opt]: The type of NWM forecast to grab. Valid values are 'short', 'medium', or 'long'.
 
 	Returns:


### PR DESCRIPTION
Integrating model cycle information (though the **hour field of the `forecast_start` parameter** in **configuration.json**. The `forecast_start` argument is passed along to the data getters in the prep_script, and the data getters infer the model cycle from the  passed start date. The `forecast_end` paramter _is also modified_ to include the model cycle hour, so that when the duration of the forecast simulation period is guaranteed to be calculated accurately (it is calculated as the number of days difference between forecast start and end). Model cycle information is also accordingly added to the debug scripts.