### PR TITLE
Make the forecast-workflow repository path configurable

### DIFF
--- a/batch/experiment_configTEMPLATE.json
+++ b/batch/experiment_configTEMPLATE.json
@@ -11,7 +11,7 @@
 	"hydrology_dataset_spinup" : "USGS_IV",
 	"hydrology_dataset_forecast" : "NOAA_NWM_PROD",
 	"nwm_forecast_member" : "<nwm_forecast_member>",
-	"data_dir" : "/netfiles/ciroh/hindcastData/",
+	"data_dir" : "/netfiles/ciroh/downloadedData/",
 	"aem3d_command_path" : "/users/n/b/nbeckage/ciroh/aem3d-1.1.2-535/aem3d_openmp.exe",
 	"cqVersion" : "<cqVersion>"
 }

--- a/batch/experiment_configTEMPLATE.json
+++ b/batch/experiment_configTEMPLATE.json
@@ -13,5 +13,6 @@
 	"nwm_forecast_member" : "<nwm_forecast_member>",
 	"data_dir" : "/netfiles/ciroh/downloadedData/",
 	"aem3d_command_path" : "/users/n/b/nbeckage/ciroh/aem3d-1.1.2-535/aem3d_openmp.exe",
+	"forecast-workflow_path" : "/users/n/b/nbeckage/ciroh/repos/prod/forecast-workflow",
 	"cqVersion" : "<cqVersion>"
 }

--- a/batch/launchExperiment.py
+++ b/batch/launchExperiment.py
@@ -40,8 +40,12 @@ except IndexError:
 # load in the default run config file
 config = get_args.load_defaults()
 
+# file_dir is the directory in which launchExperiment.py is located
+file_dir = os.path.dirname(__file__)
+# now make the path to submitTEMPLATE.sh, which should be in the same dir as launchExperiment.py
+submit_template = os.path.join(file_dir, 'submitTEMPLATE.sh')
 # load in the default job script template
-with open('/users/n/b/nbeckage/ciroh/forecast-workflow/batch/submitTEMPLATE.sh') as f:
+with open(submit_template) as f:
 	src = Template(f.read())
 
 ### 6/11/24 - I think this is outdated - orig will be the scenario dir (same dir as experiemnt_config)

--- a/batch/launchExperiment.py
+++ b/batch/launchExperiment.py
@@ -70,7 +70,7 @@ for year in years:
 		dates = random.sample(dates, test)
 	spinup_month_and_day = dt.datetime.strptime(experiment_launch_params['spinup_date'], "%m%d")
 	# get the length of the forecast in days (7 days, 30, etc)
-	forecast_days = int(experiment_launch_params['forecast_days'])
+	forecast_days = float(experiment_launch_params['forecast_days'])
 	for date in dates:
 		scenario_dir_date = os.path.join(scenario_dir_year,date.strftime('%Y%m%d.t%Hz'))
 		# if the run exists, skip it
@@ -96,8 +96,15 @@ for year in years:
 			json.dump(config, config_file, indent=2)
 			config_file.write('\n')
 
+		# read in the path to the forecast-workflow repo that you want to use for the runs
+		py_path = experiment_launch_params['forecast-workflow_path']
+		# check that the path is a directory
+		if not os.path.isdir(py_path):
+			raise OSError(f"py_path is not a directory: {py_path}")
+
 		# define the job params for the run
 		job_params = {'job_name':f'{experiment_launch_params["job_name_prefix"]}{date.strftime("%Y%m%d.t%Hz")}',
+					  'py_path':py_path,
 			  		  'run_dir':scenario_dir_date}
 		job_script = src.substitute(job_params)
 

--- a/batch/launchScenarioTEMPLATE.sh
+++ b/batch/launchScenarioTEMPLATE.sh
@@ -25,4 +25,4 @@ TEST=$4
 cd /netfiles/ciroh/<hindcast_dir>/<cq_dir>/$SCENARIO_DIR/
 
 # note that you must have an experiment-specific configuration file in your scenario directory
-python /users/n/b/nbeckage/ciroh/forecast-workflow/batch/launchExperiment.py experiment_config.json $START_YEAR $END_YEAR $TEST
+python /users/n/b/nbeckage/ciroh/repos/prod/forecast-workflow/batch/launchExperiment.py experiment_config.json $START_YEAR $END_YEAR $TEST

--- a/batch/submitTEMPLATE.sh
+++ b/batch/submitTEMPLATE.sh
@@ -27,7 +27,7 @@ source /users/n/b/nbeckage/miniconda3/etc/profile.d/conda.sh
 conda activate forecast
 
 # export PYTHONPATH=/users/p/c/pclemins/repos/forecast-workflow
-export PYTHONPATH=/users/n/b/nbeckage/ciroh/repos/prod/forecast-workflow
+export PYTHONPATH=$py_path
 
 cd $run_dir
 

--- a/batch/submitTEMPLATE.sh
+++ b/batch/submitTEMPLATE.sh
@@ -27,7 +27,7 @@ source /users/n/b/nbeckage/miniconda3/etc/profile.d/conda.sh
 conda activate forecast
 
 # export PYTHONPATH=/users/p/c/pclemins/repos/forecast-workflow
-export PYTHONPATH=/users/n/b/nbeckage/ciroh/forecast-workflow
+export PYTHONPATH=/users/n/b/nbeckage/ciroh/repos/prod/forecast-workflow
 
 cd $run_dir
 


### PR DESCRIPTION
The changes in this branch arose because I wanted to create a stable production copy of repository that could be used to launch runs while I simultaneously work on new features in a development copy of the repository. So, I had to make sure that when I launch a suite of runs, the workflow knows which copy of the repository to use. So, I made a new setting, called `"forecast-workflow_path"` that specifies just that. I also adjusted `launchExperiment.py` so that it looks for `submitTEMPLATE.sh` relatively rather than at some hardcoded location.

Also included here: 
- change default `"data_dir"` to `/netfiles/ciroh/downloadedData/`
- cast `experiment_launch_params['forecast_days']` as a float rather than an int; this is handy for having more control over the length of the forecast period for a given run. For example, with Rakhshinda's t18z scenario, we need to specify the forecast_days setting to be 29.25 (29 days, 6 hours), so that when the forecast is launched at 05/01 18:00, the last timestep AEM3D will simulate will be 05/31 00:00 rather than 05/31 18:00 (this later time caused issues with the lake level files, which have daily values set at 12:00)