### PR TITLE
Changes for Launching Peter's Long-term Hindcast v2

### DIFF
--- a/batch/debug/feeDebug.py
+++ b/batch/debug/feeDebug.py
@@ -273,8 +273,11 @@ def main():
 					outfile = [f for f in os.listdir(run_dir) if f.endswith(file_string)]
 					# the list above should have a length of exactly 1 (there should be one outfile)
 					# raise a warning if for some reason ther is more than 1 outfile
-					if len(outfile) != 1:
-						warnings.warn(f"Multiple outfiles detected: {outfile}")
+					if len(outfile) > 1:
+						warnings.warn(f"\t\t\t Multiple outfiles detected: {outfile}")
+					elif len(outfile) < 1:
+						log_print(f"\t\t\t NO OUTFILE DETECTED IN: {run_dir}")
+						continue
 					outfile = outfile[0]
 
 					# create full file path

--- a/batch/debug/feeDebug.py
+++ b/batch/debug/feeDebug.py
@@ -266,7 +266,7 @@ def main():
 					# log_print(f"RUN_DIR: {run_dir}")
 					# skip to try the next run dir if the current one does not exist
 					if not os.path.exists(run_dir):
-						log_print('run dir does note exist')
+						log_print('run dir does not exist')
 						continue
 
 					# list the directory and filter to get just the outfile
@@ -277,6 +277,8 @@ def main():
 						warnings.warn(f"\t\t\t Multiple outfiles detected: {outfile}")
 					elif len(outfile) < 1:
 						log_print(f"\t\t\t NO OUTFILE DETECTED IN: {run_dir}")
+						log_print(f"\t\t REMOVING RUN DIR: {run_dir}")
+						shutil.rmtree(run_dir)
 						continue
 					outfile = outfile[0]
 

--- a/default_settings.json
+++ b/default_settings.json
@@ -1,7 +1,7 @@
 {
+	"spinup_date" : "20230101",
 	"forecast_start" : "20230701",
 	"forecast_end" : "20230708",
-	"spinup_date" : "20230101",
 	"output_write_start_datetime" : "",
 	"output_write_iteration_hours" : 24,
 	"output_write_file_path" : "./restarts",
@@ -14,9 +14,12 @@
 	"hydrology_dataset_spinup" : "USGS_IV",
 	"hydrology_dataset_forecast" : "NOAA_NWM_PROD",
 	"nwm_forecast_member" : "medium_range_mem1",
+	"use_franklin_cloudcover": true,
+	"use_btv_wind": false,
 	"csv" : false,
-	"data_dir" : "/netfiles/ciroh/hindcastData/",
+	"data_dir" : "/netfiles/ciroh/downloadedData/",
 	"aem3d_input_dir" : "/netfiles/ciroh/models/aem3d/current/AEM3D-inputs",
 	"aem3d_command_path" : "/netfiles/ciroh/models/aem3d/aem3d-1.1.2-535/aem3d_openmp.exe",
-	"cqVersion" : "202406Calibration"
+	"cqVersion" : "202406Calibration",
+	"generate_forcingdata_plots" : true
 }

--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -1036,9 +1036,9 @@ def genclimatefiles(whichbay, settings):
 			'WSPEED':'WSPEED',
 			'WDIR':'WDIR'}
 		if settings['use_btv_wind']:
-			btv_variables | {
-				'WSPEED': 'HourlyWindSpeed',
-				'WDIR'  : 'HourlyWindDirection'}
+			btv_variables = btv_variables | {
+								'WSPEED': 'HourlyWindSpeed',
+								'WDIR'  : 'HourlyWindDirection'}
 			for key in ['WSPEED', 'WDIR']:
 				del femc_variables[key]
 		

--- a/models/aem3d/get_args.py
+++ b/models/aem3d/get_args.py
@@ -15,9 +15,9 @@ settings json file, and call get_args():
 
 	settings = get_args(fpath)
 
-Now when you call AEM3D_prep_IAM.py, you can include args in the command-line call:
+Now when you call AEM3D_prep_worker.py, you can include args in the command-line call:
 
-python -m models.aem3d.AEM3D_prep_IAM --conf config.json
+python -m models.aem3d.AEM3D_prep_worker --conf config.json
 
 To add new arguments:
 	1. add arg and default value to default_settings.json


### PR DESCRIPTION
Rebased the 'peter' branch on top of the current main. This new branch, 'peter_rebased', now includes the following changes:
- Pat integrated some new forcing settings, `use_franklin_cloud_cover`, `use_btv_wind` and `generate_forcingdata_plots`
- - applied the `use_franklin_cloud_cover` to the forecast period in addition to the spinup period, which Pat implemented
- - 1 small syntax correction to Pat's changes
- fixing some broken logic I happened to notice in `feeDebug` (not necessary to launch Peter's run since it's the debug script, but still needs to be fixed nonetheless)
- - also modified `feeDebug` to delete run dirs that don't have an .out file, indicating they were never submitted. Deleting these run dirs is useful, because if the launch scripts (specifically `launchExperiment.py`) see they exist, it will assume they already ran successfully and it won't try to run them again.