### PR TITLE
Bug fixes for NWM forcings data module

### DIFF
--- a/data/nwm_forcings_fc.py
+++ b/data/nwm_forcings_fc.py
@@ -447,11 +447,11 @@ def process_nwm_forcings(
 		utils.add_units(nwm_forcings_data, var_units)
 
 		# now convert the dataset's nearest x,y coordinates into lat,lon. These are the lat,lon coords in the dataset that are nearest to the requested lat,lon points
-		nearest_xy_to_wgs = [nwm_to_wgs.transform(x, y) for (x, y) in nearest_xy]
+		nearest_xy_in_wgs = [nwm_to_wgs.transform(x, y) for (x, y) in nearest_xy]
 		# create a dictionary where the keys are the user-requested lat,lon coords, and values are the nearest la,lon values in the dataset
-		req_to_act_coords = {requested_coord : (lat, lon) for requested_coord, (lon, lat) in zip(locations['points'].values(), nearest_xy_to_wgs)}
+		real_coords_for_locs = {locname : (lat, lon) for locname, (lon, lat) in zip(locations['points'].keys(), nearest_xy_in_wgs)}
 		# this list comp will add the actual grid coords to the dictionary for each requested point 
-		[nwm_forcings_data[requested].update(grid_coords=nearest) for requested, nearest in req_to_act_coords.items()]
+		[nwm_forcings_data[locname].update(grid_coords=nearest) for locname, nearest in real_coords_for_locs.items()]
 
 	print('TASK COMPLETE: PROCESS NWM FORCINGS DATA')
 	return nwm_forcings_data

--- a/examples/get_data_demo.ipynb
+++ b/examples/get_data_demo.ipynb
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "id": "08f75820-a8a1-4a3a-9929-2f70757a905c",
    "metadata": {},
    "outputs": [],
@@ -35,58 +35,45 @@
    "id": "01cc2623",
    "metadata": {},
    "source": [
-    "## NWM forecasted streamflow data\n"
+    "## NWM forecasted streamflow data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "id": "ef3c2125",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'\\nA function to download and process NWM hydrology forecast data to return nested dictionary of pandas series fore each variable, for each location.\\n\\nArgs:\\n-- forecast_datetime (str, date, or datetime) [req]: the start date and time (00, 06, 12, 18) of the forecast to download. Times are assumed to be UTC time.\\n-- end_datetime (str, date, or datetime) [req]: the end date and time for the forecast. GFS forecasts 16-days out for a given start date.\\n-- locations (dict) [req]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to download forecast data for.\\n-- forecast_type (str) [req]: The type of forecast.\\n-- data_dir (str) [opt]: directory to store donwloaded data. Defaults to OS\\'s default temp directory.\\n-- dwnld_threads (int) [opt]: number of threads to use for downloads. Default is half of OS\\'s available threads.\\n-- load_threads (int) [opt]: number of threads to use for reading data. Default is 2 for GFS, since file reads are already pretty fast.\\n-- forecast_cycle (str) [req]: The starting time for the forecasts. valid values are 00, 06, 12, 18\\n-- google_buckets (bool) [opt]: Flag determining wether or not to use google buckets for nwm download as opposed to NOMADs site.\\n-- archive (bool) [opt]: Flag determining wether or not data you are grabbing is older than the last two days (relevant for NWM only)\\n-- return_type (string) [opt]: string indicating which format to return data in. Default is \"dict\", which will return data in a nested dict format:\\n\\t\\t\\t\\t\\t\\t\\t\\t{locationID1:{\\n\\t\\t\\t\\t\\t\\t\\t\\t\\tvar1_name:pd.Series,\\n\\t\\t\\t\\t\\t\\t\\t\\t\\tvar2_name:pd.Series,\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t...},\\n\\t\\t\\t\\t\\t\\t\\t\\tlocationID2:{...},\\n\\t\\t\\t\\t\\t\\t\\t\\t...\\n\\t\\t\\t\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t\\t\\t\\t\\tAlternative return type is \"dataframe\", which smashes all data into a single dataframe muliIndex\\'d by station ID, then timestamp\\t\\nReturns:\\nNWM data in the format specified by return_type\\n'"
-      ]
-     },
-     "execution_count": 2,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "\"\"\"\n",
-    "A function to download and process NWM hydrology forecast data to return nested dictionary of pandas series fore each variable, for each location.\n",
+    "'''\n",
+    "A function to download and process NWM hydrology forecast data to return nested dictionary of pandas series for each variable, for each location.\n",
     "\n",
     "Args:\n",
-    "-- forecast_datetime (str, date, or datetime) [req]: the start date and time (00, 06, 12, 18) of the forecast to download. Times are assumed to be UTC time.\n",
-    "-- end_datetime (str, date, or datetime) [req]: the end date and time for the forecast. GFS forecasts 16-days out for a given start date.\n",
-    "-- locations (dict) [req]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to download forecast data for.\n",
-    "-- forecast_type (str) [req]: The type of forecast.\n",
-    "-- data_dir (str) [opt]: directory to store donwloaded data. Defaults to OS's default temp directory.\n",
-    "-- dwnld_threads (int) [opt]: number of threads to use for downloads. Default is half of OS's available threads.\n",
-    "-- load_threads (int) [opt]: number of threads to use for reading data. Default is 2 for GFS, since file reads are already pretty fast.\n",
-    "-- forecast_cycle (str) [req]: The starting time for the forecasts. valid values are 00, 06, 12, 18\n",
-    "-- google_buckets (bool) [opt]: Flag determining wether or not to use google buckets for nwm download as opposed to NOMADs site.\n",
-    "-- archive (bool) [opt]: Flag determining wether or not data you are grabbing is older than the last two days (relevant for NWM only)\n",
-    "-- return_type (string) [opt]: string indicating which format to return data in. Default is \"dict\", which will return data in a nested dict format:\n",
-    "\t\t\t\t\t\t\t\t{locationID1:{\n",
-    "\t\t\t\t\t\t\t\t\tvar1_name:pd.Series,\n",
-    "\t\t\t\t\t\t\t\t\tvar2_name:pd.Series,\n",
-    "\t\t\t\t\t\t\t\t\t...},\n",
-    "\t\t\t\t\t\t\t\tlocationID2:{...},\n",
-    "\t\t\t\t\t\t\t\t...\n",
-    "\t\t\t\t\t\t\t\t}\n",
-    "\t\t\t\t\t\t\t\tAlternative return type is \"dataframe\", which smashes all data into a single dataframe muliIndex'd by station ID, then timestamp\t\n",
+    "-- start_date: The start date for which to retrieve data.\n",
+    "-- end_date: The end date for which to retrieve data.\n",
+    "-- member: The member type of NWM forecast to get (medium_range_mem1, long_range_mem3, short_range, etc).\n",
+    "-- locations: A dictionary or list of locations to pull out of the forecast files. When a dict is passed in the format {\"user-name\":\"gauge_ID\"},\n",
+    "\tthen the function will use those user-defined names when returning data. Otherwise, default location IDs found in the dataset are used.\n",
+    "-- variables: A dictionary or list of variables to pull out of the 'channel_rt' forecast files. When a dictionary is passed in the format (\"user-name\":\"variable-name\"),\n",
+    "\tthen the function will use those user-defined names when returning data. Otherwise, default variable names found in the dataset are used. \n",
+    "-- reference_date: The forecast reference time, i.e., the date and time at which \n",
+    "\tthe forecast was initialized. Defaults to start_date if None.\n",
+    "-- data_dir: Directory to store downloaded data. Defaults to OS's default temp directory.\n",
+    "-- format: The format in which to return the data. Default is 'dictionary', which returns a nested dictionary of pandas series. Other valid option is 'xarray', which returns an xarray dataset.\n",
+    "-- gcs: Flag determining whether or not to use Google buckets for NWM download as opposed to NOMADs site. Default is True.\n",
+    "-- end_date_exclusive: Whether to exclude the end date from the time series. Defaults to True.\n",
+    "-- dwnld_threads: Number of threads to use for downloads. Default is half of OS's available threads.\n",
+    "-- load_threads: Number of threads to use for reading data. Default is half of OS's available threads.\n",
+    "\n",
     "Returns:\n",
-    "NWM data in the format specified by return_type\n",
-    "\"\"\""
+    "NWM timeseries for the given locations in a nested dict format where 1st-level keys are user-provided location names and 2nd-level keys\n",
+    "are variable names and values are the respective data in a Pandas Series object, or an xarray Dataset if format='xarray'.\n",
+    "'''"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "52c1d4d0-8595-4cde-bb53-9550ef55133a",
    "metadata": {
     "scrolled": true
@@ -114,285 +101,129 @@
     "\n",
     "# define a directory in which to download NWM data\n",
     "# this specifc directroy hosts a large swath of NWM and GFS data used collectively by CIROH researchers\n",
-    "data_directory = \"/netfiles/ciroh/downloadedData/\"\n",
-    "\n",
-    "# yes, we want to use google buckets for all data older than yesterday\n",
-    "buckets = True\n",
-    "arch = True\n"
+    "data_directory = \"/netfiles/ciroh/downloadedData/\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "296fab2c",
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "TASK INITIATED: Download 237-hour NWM hydrology forecasts for the following date: 20240116\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f003.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f003.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f006.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f006.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f009.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f009.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f012.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f012.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f015.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f015.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f018.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f018.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f021.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f021.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f024.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f024.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f027.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f027.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f030.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f030.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f033.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f033.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f036.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f036.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f039.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f039.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f042.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f042.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f045.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f045.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f048.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f048.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f051.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f051.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f054.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f054.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f057.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f057.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f060.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f060.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f063.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f063.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f066.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f066.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f069.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f069.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f072.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f072.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f075.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f075.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f078.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f078.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f081.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f081.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f084.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f084.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f087.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f087.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f090.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f090.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f093.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f093.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f096.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f096.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f099.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f099.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f102.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f102.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f105.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f105.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f108.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f108.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f111.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f111.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f114.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f114.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f117.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f117.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f120.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f120.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f123.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f123.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f126.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f126.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f129.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f129.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f132.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f132.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f135.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f135.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f138.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f138.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f141.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f141.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f144.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f144.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f147.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f147.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f150.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f150.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f153.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f153.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f156.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f156.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f159.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f159.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f162.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f162.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f165.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f165.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f168.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f168.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f171.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f171.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f174.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f174.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f177.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f177.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f180.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f180.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f183.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f183.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f186.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f186.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f189.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f189.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f192.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f192.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f195.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f195.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f198.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f198.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f201.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f201.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f204.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f204.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f207.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f207.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f210.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f210.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f213.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f213.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f216.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f216.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f219.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f219.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f222.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f222.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f225.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f225.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f228.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f228.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f231.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f231.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f234.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f234.conus.nc\n",
-      "Skipping download; nwm.t06z.medium_range.channel_rt_1.f237.conus.nc found at: /netfiles/ciroh/7dayHABsHindcast/hindcastData/nwm/2024/nwm.20240116/medium_range_mem1/nwm.t06z.medium_range.channel_rt_1.f237.conus.nc\n",
-      "TASK COMPLETE: NWM DOWNLOAD\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
-    "nwm_data = nwm.get_data(forecast_datetime = fc_start_dt,\n",
-    "\t\t\t \t\t   end_datetime = fc_end_dt,\n",
-    "\t\t\t \t\t   locations = reaches,\n",
-    "\t\t\t\t\t   forecast_type = fc_type,\n",
-    "\t\t\t\t\t   data_dir = data_directory,\n",
-    "\t\t\t\t\t   google_buckets = buckets,\n",
-    "\t\t\t\t\t   archive = arch)"
+    "nwm_data = nwm.get_data(start_date=fc_start_dt,\n",
+    "\t\t\t\t\t\tend_date=fc_end_dt,\n",
+    "\t\t\t\t\t\tmember=fc_type,\n",
+    "\t\t\t\t\t\tlocations=reaches,\n",
+    "\t\t\t\t\t\tdata_dir=data_directory,\n",
+    "\t\t\t\t\t\tvariables={'discharge':'streamflow'},\n",
+    "\t\t\t\t\t\tformat='dictionary',\n",
+    "      \t\t\t\t\tend_date_exclusive=False) # by default, the end date is excluded from the time series"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "4382e2ef-8165-4062-9614-bd5e5d923d09",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "{'Missisquoi River': {'streamflow': time\n",
-       "  2024-01-16 09:00:00+00:00    62.669999\n",
-       "  2024-01-16 12:00:00+00:00    63.149999\n",
-       "  2024-01-16 15:00:00+00:00    62.909999\n",
-       "  2024-01-16 18:00:00+00:00    62.119999\n",
-       "  2024-01-16 21:00:00+00:00    61.089999\n",
-       "                                 ...    \n",
-       "  2024-01-25 15:00:00+00:00    23.609999\n",
-       "  2024-01-25 18:00:00+00:00    23.489999\n",
-       "  2024-01-25 21:00:00+00:00    23.399999\n",
-       "  2024-01-26 00:00:00+00:00    23.989999\n",
-       "  2024-01-26 03:00:00+00:00    24.399999\n",
-       "  Name: streamflow, Length: 79, dtype: float64},\n",
-       " 'Jewett Brook': {'streamflow': time\n",
-       "  2024-01-16 09:00:00+00:00    0.20\n",
-       "  2024-01-16 12:00:00+00:00    0.40\n",
-       "  2024-01-16 15:00:00+00:00    0.65\n",
-       "  2024-01-16 18:00:00+00:00    0.78\n",
-       "  2024-01-16 21:00:00+00:00    0.82\n",
-       "                               ... \n",
-       "  2024-01-25 15:00:00+00:00    0.32\n",
-       "  2024-01-25 18:00:00+00:00    0.31\n",
-       "  2024-01-25 21:00:00+00:00    0.31\n",
-       "  2024-01-26 00:00:00+00:00    0.31\n",
-       "  2024-01-26 03:00:00+00:00    0.31\n",
-       "  Name: streamflow, Length: 79, dtype: float64},\n",
-       " 'Mill River': {'streamflow': time\n",
-       "  2024-01-16 09:00:00+00:00    1.33\n",
-       "  2024-01-16 12:00:00+00:00    1.05\n",
-       "  2024-01-16 15:00:00+00:00    0.91\n",
-       "  2024-01-16 18:00:00+00:00    0.83\n",
-       "  2024-01-16 21:00:00+00:00    0.79\n",
-       "                               ... \n",
-       "  2024-01-25 15:00:00+00:00    0.42\n",
-       "  2024-01-25 18:00:00+00:00    0.43\n",
-       "  2024-01-25 21:00:00+00:00    0.70\n",
-       "  2024-01-26 00:00:00+00:00    5.04\n",
-       "  2024-01-26 03:00:00+00:00    5.61\n",
-       "  Name: streamflow, Length: 79, dtype: float64}}"
-      ]
-     },
-     "execution_count": 8,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "nwm_data"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "7b1ded11",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>streamflow</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>time</th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>2024-01-16 09:00:00+00:00</th>\n",
-       "      <td>62.669999</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-16 12:00:00+00:00</th>\n",
-       "      <td>63.149999</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-16 15:00:00+00:00</th>\n",
-       "      <td>62.909999</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-16 18:00:00+00:00</th>\n",
-       "      <td>62.119999</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-16 21:00:00+00:00</th>\n",
-       "      <td>61.089999</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-25 15:00:00+00:00</th>\n",
-       "      <td>23.609999</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-25 18:00:00+00:00</th>\n",
-       "      <td>23.489999</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-25 21:00:00+00:00</th>\n",
-       "      <td>23.399999</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-26 00:00:00+00:00</th>\n",
-       "      <td>23.989999</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-26 03:00:00+00:00</th>\n",
-       "      <td>24.399999</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>79 rows × 1 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                           streamflow\n",
-       "time                                 \n",
-       "2024-01-16 09:00:00+00:00   62.669999\n",
-       "2024-01-16 12:00:00+00:00   63.149999\n",
-       "2024-01-16 15:00:00+00:00   62.909999\n",
-       "2024-01-16 18:00:00+00:00   62.119999\n",
-       "2024-01-16 21:00:00+00:00   61.089999\n",
-       "...                               ...\n",
-       "2024-01-25 15:00:00+00:00   23.609999\n",
-       "2024-01-25 18:00:00+00:00   23.489999\n",
-       "2024-01-25 21:00:00+00:00   23.399999\n",
-       "2024-01-26 00:00:00+00:00   23.989999\n",
-       "2024-01-26 03:00:00+00:00   24.399999\n",
-       "\n",
-       "[79 rows x 1 columns]"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "pd.DataFrame(nwm_data['Missisquoi River']['streamflow'])"
+    "pd.DataFrame(nwm_data['Missisquoi River']['discharge'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "10682ed8",
+   "metadata": {},
+   "source": [
+    "## NWM Forcings Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f17fc480",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import data.nwm_forcings_fc as nwm_forcings\n",
+    "\n",
+    "'''\n",
+    "A function to download and process NWM forcings data.\n",
+    "\n",
+    "Args:\n",
+    "-- start_date: The start date for which to retrieve data.\n",
+    "-- end_date: The end date for which to retrieve data.\n",
+    "-- member: The NWM forecast member for which you to get forcings for (Currently accepts 'medium_range', 'short_range', 'analysis_assim', and 'analysis_assim_extend').\t-- locations: A dictionary containing either bounding box information or a list of points to extract from the gridded forcings dataset. Default value of None does not spatially subset the data. See validate_locations() for more details.\n",
+    "\tNote that the bounding box must be in latitude, longitude (WGS 1984), but the dataset is NOT reprojected and will maintain its orginal CRS.\n",
+    "-- locations: A dictionary containing either bounding box information or a dict of points to extract from the gridded forcings dataset. Default value of None does not spatially subset the data. See validate_locations() for more details.\n",
+    "\tNote that the bounding box must be in latitude, longitude (WGS 1984), but the dataset is NOT reprojected and will maintain its orginal CRS.\n",
+    "-- variables: A dictionary or list of variables to pull out of the forcing files. When a dictionary is passed in the format {\"user-name\":\"variable-name\"}, the function will use those user-defined names when returning data. Otherwise, the variable names found in the dataset are used. Default value 'all' keeps all variables\n",
+    "-- reference_date: The forecast reference time, i.e., the date and time at which \n",
+    "\tthe forecast for which you want forcings for was initialized. Defaults to start_date if None.\n",
+    "-- data_dir: Directory to store downloaded data. Defaults to OS's default temp directory.\n",
+    "-- end_date_exclusive: Whether to exclude the end date from the time series. Defaults to True.\n",
+    "-- dwnld_threads: Number of threads to use for downloads. Default is half of OS's available threads.\n",
+    "\n",
+    "Returns:\n",
+    "xr.Dataset or dict: If locations is None or a bounding box, returns an xarray.Dataset. If locations specifies points, returns a nested dictionary where 1st-level keys are points, 2nd-level keys are variables, and 2nd-level values are pandas.Series\n",
+    "'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06a24a93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The NWM Forcings data getter is unique in that it can return data in two formats: an xarray dataset or a nested dictionary of pandas series.\n",
+    "# the format the data is returned in is determined by the nature of the locations argument passed in.\n",
+    "\n",
+    "# If locations is a bounding box, the data will be returned as an xarray dataset.\n",
+    "boundary_box = {'bbox' : {'min_lat' : 42.34, 'max_lat' : 45.21, 'min_lon' : -75.89, 'max_lon' : -72.68}}\n",
+    "# If locations is a dictionary of labelled points, the data will be returned as a nested dictionary\n",
+    "labelled_points = {'points': {'01413088': (42.29380556, -74.5591944),\n",
+    "                        \t  '01413398': (42.1508333, -74.60138889)}}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ca17b3a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "forcings_data = nwm_forcings.get_data(start_date=fc_start_dt,\n",
+    "\t\t\t\t\t\t\t\t\t end_date=fc_end_dt,\n",
+    "\t\t\t\t\t\t\t\t\t member=\"medium_range\",\n",
+    "\t\t\t\t\t\t\t\t\t locations=boundary_box,  # or labelled_points\n",
+    "\t\t\t\t\t\t\t\t\t variables='all',\n",
+    "\t\t\t\t\t\t\t\t\t data_dir=data_directory,\n",
+    "          \t\t\t\t\t\t\t end_date_exclusive=True) # by default, the end date is excluded from the time series"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a51de5c8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Note that since we passed in a boundary box, the data is returned as an xarray dataset.\n",
+    "# if we passed in a dictionary of labelled points, the data would be returned as a nested dictionary of pandas series.\n",
+    "# the later method is not recommended for large datasets, as it can be very memory intensive and take a long time to execute\n",
+    "forcings_data"
    ]
   },
   {
@@ -407,23 +238,12 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "74210347",
    "metadata": {
     "scrolled": true
    },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'\\nA function to download and process USGS observational hydrology data to return nested dictionary of pandas series fore each variable, for each location.\\n\\nArgs:\\n-- start_date (str, date, or datetime) [req]: the start date for which to grab USGS data\\n-- end_date (str, date, or datetime) [req]: the end date for which to grab USGS data\\n-- locations (dict) [req]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to get USGS data for.\\n-- return_type (string) [opt]: string indicating which format to return data in. Default is \"dict\", which will return data in a nested dict format:\\n\\t\\t\\t\\t\\t\\t\\t{locationID1:{\\n\\t\\t\\t\\t\\t\\t\\t\\tvar1_name:pd.Series,\\n\\t\\t\\t\\t\\t\\t\\t\\tvar2_name:pd.Series,\\n\\t\\t\\t\\t\\t\\t\\t\\t...},\\n\\t\\t\\t\\t\\t\\t\\tlocationID2:{...},\\n\\t\\t\\t\\t\\t\\t\\t...\\n\\t\\t\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t\\t\\t\\tAlternative return type is \"dataframe\", which smashes all data into a single dataframe muliIndex\\'d by station ID, then timestamp\\n\\nReturns:\\nUSGS observed streamflow data for the given stations in the format specified by return_type\\n'"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"\n",
     "A function to download and process USGS observational hydrology data to return nested dictionary of pandas series fore each variable, for each location.\n",
@@ -432,24 +252,18 @@
     "-- start_date (str, date, or datetime) [req]: the start date for which to grab USGS data\n",
     "-- end_date (str, date, or datetime) [req]: the end date for which to grab USGS data\n",
     "-- locations (dict) [req]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to get USGS data for.\n",
-    "-- return_type (string) [opt]: string indicating which format to return data in. Default is \"dict\", which will return data in a nested dict format:\n",
-    "\t\t\t\t\t\t\t{locationID1:{\n",
-    "\t\t\t\t\t\t\t\tvar1_name:pd.Series,\n",
-    "\t\t\t\t\t\t\t\tvar2_name:pd.Series,\n",
-    "\t\t\t\t\t\t\t\t...},\n",
-    "\t\t\t\t\t\t\tlocationID2:{...},\n",
-    "\t\t\t\t\t\t\t...\n",
-    "\t\t\t\t\t\t\t}\n",
-    "\t\t\t\t\t\t\tAlternative return type is \"dataframe\", which smashes all data into a single dataframe muliIndex'd by station ID, then timestamp\n",
+    "-- variables (dict) [req]: a dictionary of variables to download, where keys are user-defined variable names and values are dataset-specific variable names.\n",
+    "-- service (str) [opt]: what USGS service to get data from. Default is instanteous values service. For more options, see https://waterservices.usgs.gov/docs/\n",
     "\n",
     "Returns:\n",
-    "USGS observed streamflow data for the given stations in the format specified by return_type\n",
+    "USGS observed streamflow data for the given stations in a nested dict format where 1st-level keys are user-provided location names and 2nd-level keys\n",
+    "are variables names and values are the respective data in a Pandas Series object.\n",
     "\"\"\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": null,
    "id": "5a0f5b22",
    "metadata": {},
    "outputs": [],
@@ -460,7 +274,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "id": "66d41c94",
    "metadata": {},
    "outputs": [],
@@ -474,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": null,
    "id": "b39fe331-60b4-468a-a29a-2c0cd11133a9",
    "metadata": {
     "scrolled": true
@@ -488,111 +302,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": null,
    "id": "6c211c74",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div>\n",
-       "<style scoped>\n",
-       "    .dataframe tbody tr th:only-of-type {\n",
-       "        vertical-align: middle;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe tbody tr th {\n",
-       "        vertical-align: top;\n",
-       "    }\n",
-       "\n",
-       "    .dataframe thead th {\n",
-       "        text-align: right;\n",
-       "    }\n",
-       "</style>\n",
-       "<table border=\"1\" class=\"dataframe\">\n",
-       "  <thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      <th></th>\n",
-       "      <th>streamflow</th>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>time</th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
-       "  </thead>\n",
-       "  <tbody>\n",
-       "    <tr>\n",
-       "      <th>2024-01-16 00:00:00+00:00</th>\n",
-       "      <td>66.261312</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-16 00:15:00+00:00</th>\n",
-       "      <td>66.261312</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-16 00:30:00+00:00</th>\n",
-       "      <td>65.411808</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-16 00:45:00+00:00</th>\n",
-       "      <td>66.261312</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-16 01:00:00+00:00</th>\n",
-       "      <td>65.411808</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>...</th>\n",
-       "      <td>...</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-26 22:45:00+00:00</th>\n",
-       "      <td>58.898944</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-26 23:00:00+00:00</th>\n",
-       "      <td>59.748448</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-26 23:15:00+00:00</th>\n",
-       "      <td>60.314784</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-26 23:30:00+00:00</th>\n",
-       "      <td>60.314784</td>\n",
-       "    </tr>\n",
-       "    <tr>\n",
-       "      <th>2024-01-26 23:45:00+00:00</th>\n",
-       "      <td>60.881120</td>\n",
-       "    </tr>\n",
-       "  </tbody>\n",
-       "</table>\n",
-       "<p>931 rows × 1 columns</p>\n",
-       "</div>"
-      ],
-      "text/plain": [
-       "                           streamflow\n",
-       "time                                 \n",
-       "2024-01-16 00:00:00+00:00   66.261312\n",
-       "2024-01-16 00:15:00+00:00   66.261312\n",
-       "2024-01-16 00:30:00+00:00   65.411808\n",
-       "2024-01-16 00:45:00+00:00   66.261312\n",
-       "2024-01-16 01:00:00+00:00   65.411808\n",
-       "...                               ...\n",
-       "2024-01-26 22:45:00+00:00   58.898944\n",
-       "2024-01-26 23:00:00+00:00   59.748448\n",
-       "2024-01-26 23:15:00+00:00   60.314784\n",
-       "2024-01-26 23:30:00+00:00   60.314784\n",
-       "2024-01-26 23:45:00+00:00   60.881120\n",
-       "\n",
-       "[931 rows x 1 columns]"
-      ]
-     },
-     "execution_count": 11,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "df = pd.DataFrame(usgs_data['Missisquoi River']['streamflow'].astype('float') * 0.0283168)\n",
     "# pd.options.display.max_rows = 60\n",
@@ -601,26 +314,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": null,
+   "id": "c01607a3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nwm_data['Missisquoi River']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "7c1f624a-22dd-4b95-b1a3-4c3ca8868318",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiMAAAHcCAYAAAAEBqrgAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjguMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8g+/7EAAAACXBIWXMAAA9hAAAPYQGoP6dpAACnZElEQVR4nO2dd5wU9f3/X7N7vXN33B0HR+9HkyJdioANRbEEQWNJTBSNmljysySS+A2oSYxG7FGwa+wVBSMggkhHej3ggCvccb3f7vz+mP3Mzu5tmd2dnc9n797Px+MeM9vf997Z+bznXSVZlmUQBEEQBEFwwsJbAIIgCIIgOjZkjBAEQRAEwRUyRgiCIAiC4AoZIwRBEARBcIWMEYIgCIIguELGCEEQBEEQXCFjhCAIgiAIrpAxQhAEQRAEV6J4C+CO3W7H6dOnkZycDEmSeItDEARBEIQOZFlGTU0NcnNzYbEE5usQzhg5ffo08vLyeItBEARBEEQQFBYWolu3bgG9RjhjJDk5GYDyz6SkpHCWhiAIgiAIPVRXVyMvL09dxwNBOGOEhWZSUlLIGCEIgiCICCOYFAtKYCUIgiAIgitkjBAEQRAEwRUyRgiCIAiC4IpwOSMEQRAEESqyLKO1tRU2m423KO0Kq9WKqKgow1tvkDFCEARBtCuam5tRVFSE+vp63qK0SxISEtClSxfExMQY9p5kjBAEQRDtBrvdjoKCAlitVuTm5iImJoYaaBqELMtobm7GmTNnUFBQgH79+gXc3MwbZIwQBEEQ7Ybm5mbY7Xbk5eUhISGBtzjtjvj4eERHR+P48eNobm5GXFycIe9LCawEQRBEu8OoK3aiLeHQLX1bBEEQBEFwhYwRgiAIgiC4QsYIQRAEQRBcIWOEIAiCIATgxhtvhCRJeOyxx1zu/+STTyBJEmpraxEdHY333nvP5fFf/OIXkCQJR44ccbm/T58+ePDBBwEAixYtgiRJuPDCC9t87hNPPAFJkjB16lRj/6EA6DjGiN0GrHkM+Op+YOPzgK2Vt0QEQRAE4UJcXBwef/xxVFRUtHksKSkJo0ePxurVq13uX7t2LfLy8lzuP3nyJI4ePYpp06ap93Xp0gWrV6/GyZMnXV6/bNkydO/e3eD/JDA6mDGyBNj0IvD1/wO2vMpbIoIgCMIEZFlGfXOr6X+yLAcs64wZM5CTk4MlS5Z4fHzatGlYs2aNenvfvn1oaGjAwoULXe5fvXo1oqOjMXHiRPW+rKwszJo1C6+99pp634YNG1BWVoZLLrkkYFmNpOP0GZHc7K6CtcDY3/CRhSAIgjCNhhYbBv/5G9M/d+9fL0BCTGDLrNVqxeLFizF//nzceeed6Natm8vj06ZNw5IlS1BUVKR6OiZPnozp06dj6dKl6vNWr16NsWPHtum1cvPNN+P+++/HQw89BAB49dVXsWDBgiD/Q+PoOJ4RaxQw/U+8pSAIgiAIn1xxxRUYMWIEHnnkkTaPTZw4EdHR0aoXZM2aNZgyZQpGjhyJqqoqHDp0SL1fG6JhzJ49G9XV1fj+++9RV1eH//73v7j55pvD+v/ooeN4RgAgPo23BARBEITJxEdbsfevF3D53GB5/PHHMX36dNxzzz0u9yckJODcc8/FmjVrcO2112Lt2rW47777EBUVhYkTJ2LNmjWIjY1FQUEBpk+f3uZ9o6Ojcd1112HZsmU4evQo+vfvj2HDhgUtp1F0LGMkNoW3BARBEITJSJIUcLiEN+eddx4uuOACPPjgg7jxxhtdHps2bRree+897NmzBw0NDRg5ciQAYMqUKVi9ejViYmIQFxeHcePGeXzvm2++GWPHjsXu3buF8IoAHSlMA7jmjQSRWEQQBEEQZvHYY4/h888/x4YNG1zunzZtGg4dOoS3334bkyZNgtWqeGCmTJmCNWvWYM2aNRg/frzXuTH5+fnIz8/H7t27MX/+/LD/H3roWMaIlhYaLU0QBEGIy9ChQ7FgwQI888wzLvdPmDABsbGxeOaZZzBlyhT1/jFjxqCqqgoffvihx3wRLd999x2KioqQlpYWDtEDpmMZIz2cJU6oL+cnB0EQBEHo4NFHH21TIsxCMDU1NS6NyqKjozF+/HjU1NT4NUYSExOFMUQAQJKDKYQOI9XV1UhNTUVVVRVSUsKQ47H/K+Dda4GkHODeA8a/P0EQBMGNxsZGFBQUoFevXoaNtydc8abjUNbvjuUZAYDcc5RtXanSCI0gCIIgCK50PGMksTMACZDtFKohCIIgCAHoeMaINQpIyFD2a0v4ykIQBEEQRAc0RgAgNlnZNtfxlYMgCIIgiA5qjEQ7evW3NPCVgyAIgiCIjmqMxCtbMkYIgiAIgjsd3BihxmcEQRAEwZsOaoxQmIYgCIIgRKGDGiMUpiEIgiAIUeigxgjzjFCYhiAIghCDqVOn4u67725z/yeffAJJkgAANpsNS5YswcCBAxEfH4/09HSMGzcOy5Ytc3lNcXEx7rrrLvTt2xdxcXHIzs7GpEmT8MILL6C+3rn2bd++HbNnz0ZWVhbi4uLQs2dP/OIXv0BZWVlY/1d3ImumslEwz0hrI185CIIgCCIAFi1ahJdeeglLly7F6NGjUV1djS1btqCiokJ9ztGjRzFx4kSkpaVh8eLFGDp0KFpbW3Hw4EG8+uqryM3NxWWXXYbS0lLMmDEDl156Kb755hukpaWhoKAAn332mYvBYgYd2xghzwhBEAQRQXz++edYuHAhrr76avW+4cOHuzxn4cKFiIqKwpYtW5CYmKjeP3ToUFx55ZXq4L0NGzaguroa//nPfxAVpZgDvXr1wvTp0034T1zpoGEayhkhCILoMMiy0uTS7L8wzKHNycnBd999hzNnznh8vLy8HCtXrsTtt9/uYohoYSGfnJwctLa24uOPP24zGdhsOrZnpJk8IwRBEO2elnpgca75n/vgaSDGs0EQLE8++SSuuuoq5OTkID8/HxMmTMCcOXNw0UUXAQAOHz4MWZYxYMAAl9dlZmaisVFJTbj99tvx+OOPY9y4cXjwwQcxf/583HrrrTj33HMxffp0/PKXv0R2drahcvujY3pG2Gya+tATdGqbWrlblARBEETHYPDgwdi9ezc2btyIm266CSUlJbj00kvx61//2uV5zPvB2LRpE3bs2IH8/Hw0NTWp9//tb39DcXExXnjhBQwePBgvvPACBg4ciF27dpny/zA6pmckKUfZ1hQH/RYNzTb89Yu9eGfTCQzMScbckV0xZ0RXZKfEGSQkQRAEYQjRCYqXgsfnBkBKSgqqqqra3F9ZWYmUlBT1tsViwZgxYzBmzBj8/ve/x5tvvonrr78eDz30EPr27QtJkrB//36X9+jduzcAID4+vs37Z2Rk4Oqrr8bVV1+NJUuW4JxzzsE//vEPvPbaawHJHwod1BjJUrZBTu09WFKDO97ehoMltQCA/cU1WPzVfjy2Yj8m9euMK0d2xUVDuiAmqmM6ngiCIIRCkgwPl4SDgQMHYsWKFW3u37x5c5uwi5bBgwcDAOrq6tCrVy/MnDkTS5cuxe9+9zuveSPeiImJQZ8+fVBXZ+4g2Y5pjCQzz0gRULIHyM7X9TJZlvHOpkL85fM9aGq1o3NyLJZcMRSlNU34aNtJbDlege8PnsH3B8/g/b4nseymMYi2kkFCEARB+GfhwoVYunQpbr/9dvzmN79BfHw8Vq1ahVdeeQVvvPEGAOCqq67CxIkTMWHCBOTk5KCgoAAPPPAA+vfvj4EDBwIAnnvuOUycOBGjR4/GokWLMGzYMFgsFmzevBn79+/HqFGjAABffPEF3n33XcybNw/9+/eHLMv4/PPP8dVXX7XpWxJuOqYxkpjl3N/7mS5jpKqhBQ9+tAtf7ioCAEzp3xn/vGY4MpNiAQDzx3bHsbI6fLz9FF5edxQ/HC7Do1/sxV/nDAnLv0AQBEG0L3r27Il169bhoYcewqxZs9DY2Ij+/ftj+fLlainvBRdcgHfeeQdLlixBVVUVcnJyMH36dCxatEgtz+3Tpw+2b9+OxYsX44EHHsDJkycRGxuLwYMH495778XChQsBKB6VhIQE3HPPPSgsLERsbCz69euH//znP7j++utN/d8lWbDsy+rqaqSmpqKqqsolRmY4X/we2PIqMPY24KLHfD5VlmVctnQ9dp2qQpRFwv0XDsCvJ/WGxSJ5fP7KPcX47ZtbIcvAo5cPwfXjeoTjPyAIgiDcaGxsREFBAXr16oW4OMrhCwfedBzK+t1xYwhpDgOhsdLvUyVJwu+m90X39AR8cNsE/Oa8Pl4NEQCYlZ+De2cp8b1Fn+3BhsPmttUlCIIgiEii4xoj8WnKtrFt5rInZuXnYNUfzsOIvDRdz184tQ/mjMiFzS7jtre24ViZuclABEEQBBEpdFxjJC5V2eo0RgAgNsqq+7mSJOHxK4dheF4aqhpa8OvXt6C6sSVQKQmCIAii3UPGyPH1QF14wihx0Va8fP0o5KTE4XBpLe79705qkEYQBEEQbnRgYyTNuf+vIUCt5z7/oZKVEoeXfzka0VYJK/eW4KtdwTdaIwiCIIj2SMc1RnKGAn3OV/ZbG4Az+8L2UUO7pWLh1L4AgEc+24OqegrXEARBhBPyQoePcOi24xoj1mjg+o+AnpOV2zXBdWPVy8JpfdCncyLKapvw2NfhM3wIgiA6MtHR0QCA+noahBoumG6Zro2gYzY905LkmExYG97wSWyUFY9dOQxXv/Aj3tlUiDkjumJc74ywfiZBEERHw2q1Ii0tDaWlpQCAhISENkPjiOCQZRn19fUoLS1FWloarFb9RR3+IGOEtYbf+AJwaitw6b+BuPA0WxvTMx3zx3bH2z+dwIMf7cJXd01GXLRxXyZBEAQB5OQo53VmkBDGkpaWpurYKMgYyRqkbKtPAntOAgNnA0OvCtvH/fHCgfh2bwmOltXhudWH8YdZ3ocfEQRBEIEjSRK6dOmCrKwstLRQjp6RREdHG+oRYZAxMvxaILUbsPYJpcy3JrzhmtT4aPzlsnzc9tY2PL/2CGYPz0X/7OSwfiZBEERHxGq1hmXhJIyn4yawMixWoPdUoMsI5XaYc0cA4MIhOZg5OBstNhkPfLSLsr4JgiCIDg0ZI4xkRyJrmKtqAMWF+Nc5+UiMsWLr8Qp8tvN02D+TIAiCIGBrBXa8Axz+H2C38ZZGhYwRRnIXZVttjmHQJTUet03tAwB44usDaGwR56AgCIIg2il1Z4BPbgXeupq3JC6QMcJgiazFPwN2uykf+evJvZGbGodTlQ145YcCUz6TIAiC6MCwVITEzkqagiCQMcLoPAiITgSaqoGyA6Z8ZFy0FX+8aCAA4LnVh1Fa02jK5xIEQRAdFJaKwFITBCFgY+TUqVO47rrrkJGRgYSEBIwYMQJbt25VH5dlGYsWLUJubi7i4+MxdepU7Nmzx1Chw4I1Cug6Utk/udm0j710WC6G56WhrtmGf606aNrnEgRBEB2QWocxkmRsn5BQCcgYqaiowMSJExEdHY0VK1Zg7969+Oc//4m0tDT1OU888QSefPJJLF26FJs3b0ZOTg5mzpyJmpoao2U3nm6jlW3hJtM+0mKR8OfZSojovc2F2FdUbdpnEwRBEB2MlQ8r26QsvnK4EZAx8vjjjyMvLw/Lli3Dueeei549e+L8889Hnz5KIqYsy3jqqafw0EMPYe7cuRgyZAhee+011NfX4+233w7LP2Ao3c5Vtie3mPqxo3qk45JhXWCXgf/7ci+V+hIEQRDGY2tRUhEAoPNAvrK4EZAx8tlnn2H06NG4+uqrkZWVhXPOOQcvv/yy+nhBQQGKi4sxa9Ys9b7Y2FhMmTIFGzZsME7qcME8I2f2A41Vpn70/7twIGKsFqw/XI7v9lMLY4IgCMJg6s4498ct5CeHBwIyRo4ePYrnn38e/fr1wzfffINbb70Vd955J15//XUAQHGxkqWbne2aGJOdna0+5k5TUxOqq6td/riRlAWk9QAgA6e2mfrReekJuHlSLwDA377ah1abORU9BEEQRAeBdRhP7gJYxKpfCUgau92OkSNHYvHixTjnnHPw29/+Frfccguef/55l+e5T0iUZdnr1MQlS5YgNTVV/cvLywvwXzCYPBaqMS+JlXH7tD5IT4zB0TN1+GQHNUIjiHbJ2QJgzWPAj88qf/s+Byg0S5iBmrwqViUNEKAx0qVLFwwePNjlvkGDBuHEiRMAnJMS3b0gpaWlbbwljAceeABVVVXqX2FhYSAiGU+3McqWgzGSHBeN357XGwDwzHeHyDtCEO2Rf48A1iwBvnlQ+XvvOqB4F2+piI5ArSMFINKNkYkTJ+LAAdceHAcPHkSPHj0AAL169UJOTg5WrVqlPt7c3Iy1a9diwoQJHt8zNjYWKSkpLn9cYXkjJzdzuVq5fnwPpCfG4Hh5PXlHCKK9E5OkbOvL+MpBdAxY8mp8GlcxPBGQMfL73/8eGzduxOLFi3H48GG8/fbbeOmll3D77bcDUMIzd999NxYvXoyPP/4Yu3fvxo033oiEhATMnz8/LP+A4WQPBaLigIYKoPyI6R+fEBOF3zi8I0vJO0IQ7ZtOSp6YWV2fiQ5Ok6PFRqx4k+IDMkbGjBmDjz/+GO+88w6GDBmCRx99FE899RQWLFigPuf+++/H3XffjYULF2L06NE4deoUVq5cieRk8f55j0TFOCf4cgjVAMD14xTvyLHyenxK3hGCaD/YWl1vW6OUrUyzqQgTaC/GCADMnj0bu3btQmNjI/bt24dbbrnF5XFJkrBo0SIUFRWhsbERa9euxZAhQwwT2BS0oRoOJMY6vSOUO0IQ7Ygmt2pByTEbRKDpqUQ7ptFx/LUHY6RDwDGJlUHeEYJohzRWut5mg8rIM0KYATOGYznnZnqAjBFPsPLekj1Acx0XEcg7QhDtDFkGPr7N9T7yjBBmooZpyBiJDFJygdQ85Wrl2A/cxNB6Rz7bSd4RgohozhwACjc6b/eZTp4RwlzaU85Ih6H/Bcp2/5fcREiMjcItk5l35DB5RwgikmmocL09721AcpyCqZqGMAMyRiKQARcr24Nfcz1R/NLRd6SgrA4rdntuqU8QRARQp5k51XkQEB1PnhHCXMgYiUB6TlbiarUlwGlz59RoSYyNwi/HK03l/rPuKE30JYhIxdM0cDVnpLXtY4R/qk8Duz9U/o7/SG31/UHGSAQSFQP0naHscwzVAMB143ogJsqCnSersOV4hf8XEAQhHhv+7dzPGqRsLZTAGhJvXQ18cLPyt+xCzwYfoWC3A82UwBqZDLxE2R74iqsYmUmxuHJkVwDAy98f5SoLQRBB0Fzv3O/UE7jocWVfojBN0NjtwJn9yn50grKtoUR/rzTXOvfJMxJh9J0BWKKUA55Da3gtv5qkJLKu2leCgjI+5cYEQQRJrSPfKyoeuHMHkJSl3GZj3MkzEjgNZ53hrZxhypbCXd5hIRpLNBAVy1cWD5Ax4ov4NKDHRGWfs3ekb1YSpg/MgiwDr/5QwFUWgiACpMYxuj05G5Ak5/0W1g6eqmkCpsZh4CVkOBdXqkryjjZfRHsMCgIZI/5QQzUr+MoB4NeTlKFa728tREVdM2dpCILQzbp/KNukHNf7qelZcBz6FnjBcaGYlENVSXrY8ZayjRMvXwQgY8Q/Ay5Stid+BOrKuYoyvk8GBndJQWOLHW9vOsFVFoIgAqDS8Xt1XwhoEQ2On99z7ncbTUadHlh+TWsTXzm8QMaIP9K6AzlDFTfqoW+4iiJJEm45T/GOLN9wDE2t9MMjiIigsUrZTn/Y9X5aRIOD6XPc7cDsp8io0wPT2YVL+MrhBTJG9NDf4R05uoarGABwydBc5KTE4UxNEz6jAXoEERmwhSC+k+v9LIGVFtHAYPrsPk7RIfVr8U9DpbJNyOAqhjfIGNFDt9HKtuhnvnIAiImy4IYJPQEAr/xQQE3QCEJ0WhqB1kZlPy7V9TF1EaXEy4Bg04+ZPqlfi3+YAReXxlUMb5AxogdWNlZ2EGhp4CsLgPnndkdCjBX7i2vww+Ey3uIQBOELtghAAmLc+jtQeCE4VE9TmrJV9UhGnVfcDTjBIGNED8k5QGJn5YRRspe3NEhNiMZVo7oBAN7aSImsBCE02kXA4nbKFTlnpLEaOLZe+TsrUDsBWQZqipR9trCKrEdGazNwcquyNRutd44ZcIJBxogeJAnoMlzZL9rBVRTGgrHKvJpV+0pQUt3IWRqCILzCYvWeSiotAuc6LLsYWO74+/cIoHQ/b4kUdr3v3HcP04jsYfrsd8B/pgOf3Gb+Z298zrHjwTsnCGSM6IWFaor5540AwICcZIzu0Qk2u4z/bi7kLQ5BEN6oO6NsEzu3fUzUdvC2FqBkt7JvjVG2FYJ4R7TnYJYQHAkJrD+/q2x3f2D+Z591jBFJSG/rnRMEMaUSkS4OY0SAJFbG/LHdAQDvbi6EzU6JrAQhJKwVvHvDM0DcdvB1ZwDIyiLPvMKiLPS1pcp25l+d90VSAisznMyk1tEBeMYi8z9bJ2SM6IV5Rkr2KFcNAnDx0C5IjY/GqcoGfH/wDG9xCILwBFs8k7PbPiYJmnjJWq0nZQFWR6t1Qc57Ttk0xp3oCaw2jSGXmGn+56s683AMCkIUbwEihk69lLHLTdVKVU12Pm+JEBdtxVWjuuGVHwrw1k/HMW1gFm+RCIIPax5znR8VmwJc/HcgaxA/mRi+FgIRr+gL1gGvzVb2k7LFkrGhEihYq+wnac53oiWwVhxXckRY8rK2dNvs0tqaYmdoS2BjhDwjerFYlE6sgFChmmvPVUI13+0vxelK/mXHBGE6rc2KMVK00/l3bB2w+yPekikwz4inhUDEnJFNLzn3s4cA1mhl3y6AZ+TQKud+54HOfdESWPd8pBhN7Hgs2cVPln2fO/c79eQmhj/IGAkEwZJYAWWa77je6bDLwHuUyEp0ROpKAcjKBNwFHwCDLlXutwkyTLLWl2fE4ZwW5YoecHpyRv8KuOQfGhkFyBlhuswdCaR0cd4vmmeE6XDIlcCCD5W/yfco95ltMLEy6H4XCFvWC5AxEhhqEutOvnK4Md9R5vvu5hNotQkaMyWIcFHjSM5Lygb6zVRCqoAYiyfglM9TzoiI7eBZsuOwXwDR8U5jRIScEbbI95jger9oJdJMh93GAP1mOP5mKfeZbTAxWfLGmPu5AULGSCCwrPLiXUK1b74gPxsZiTEoqW7Cd/tLeYtDEObi7nlgi6cIyYwtjUCNY4aUp2oakdrByzJw+H9A5XHlNsvJEMl7c/BrZevuZRIpgbWhAtjzsbKvlVM9Lk3W474v2soiIGSMBEJmfyWzvKkaqDzGWxqV2Cgrrhrt6Mj6E3VkJToY7Mov2bHYi5Rw+dPzzn1PfUZEynU48h3w5lzHDcmpT1FyRqpOAuWHlf2UXNfHRArTfHW/cz9ZG0riUMZdus+ZRJuc6/OpvCFjJBCs0UD2YGVfsFDNtWOURNbvD51B4dl6ztIQhIlowzSAYDkOjpL7+HQgKqbt4yItomcOOPcv+JsSogHE0WfZIed+/wtdHxPJqDvj6FTbqSeQd67zfh5G8hlN19xe55n3uUFAxkig5IjX/AwAemYmYnK/TMgy8N8tlMhKdCBq3YwRkSpUWhwXBmNv9fy4SIsoC3eNvQ0Yf7vzflFyRlhVUq8pQGyS62MiGXXseLzmdef3C/A5LpnOBs/xbAwLBBkjgaLmjYhljADANaPzAAAfbTsFO3VkJToKtW4JompXUwE8I2zKN/MyuCNSG3NvzdlEyRnxWZUkiB7tNmf7f295LWbqMQKanTHIGAkUdWDeTiXhSyBmDs5GclwUTlU2YOPRct7iEIQ5uHfkVBdPAZIZmWfEmzEiSjv4lgZg5zvKvnuirZozwnmh91mVJIiHqa5MSaKVLG1zhMz2jNjtwA9PKvtkjLRDsvOB6ETF+i38ibc0LsRFW3HpcCVJ6YOtJzlLQxAmUe8wvNnJX6QwDRvbHp3g+XFR2sGf3uHc7zrS9THVuOMcpnH/nrWIUpXEZIxPdw3RAOZ7Rqo0xQza3BVBIWMkUKLjgfwrlP3tb/CVxQNXjVKqalbsLkZtkwCuX4IIN6xagDV0EsVlD/gP04hS+cN0mNYD6DzA9TFREliZjJ7aqYviGXE/FrWY/V03VilbySJ88ipAxkhwnHOdst39MdBUw1cWN87JS0PvzoloaLHhq11FvMUhiPBitwON1cp+XKqyFSXHAfAfphHFi8MWrvTebR9TE1h5GyMOGdn3rEWUBFY9Mpr1XTdUKtuMfuZ8XoiQMRIM3ccBGX2Bljpgzye8pXFBkiRcOVLxjlCohmj3NFUDcORusQVAiqAEVlE8I2zh8nRFL0rOiK+FXhTPCNOjLxnN9owI3AJeCxkjwSBJTu+IgKGauSO7QpKATQVncaKceo4Q7Rh2wo2KB6Ico+6F6sDKPCP+ckZEuaJPa/uYKDkjvgwmUUJzvvRo9nethrU8GEYCQsZIsAy/Vjm4Cn9ybRYkAF1S4zGpbyYA4MNt5B0h2jGeTriieBsAHZ4R5sXhbDiVOc5hHq/oRckZ0ROm4azHs0eUrS89AubI6cswEhAyRoIlOcc5+Gj7m3xl8QBLZP1w20nqOUK0XzwtUCL17mh2eEaivBkjnOaVaGltAnZ/qOx79DoIkDNia1HC4oC4CayyDGx6Sdn3aIxollszjk1fISMBIWMkFEZer2x3vsO/O6EbswbnIDk2CicrGvBTwVne4hBEeGAJ5HEpzvtEWOABZZFvdsiXkO75OSIkXlZpvKeD57R9XATPCGvIZonyHQLhqcd6zXmWVVxqkTSlvmYcm3UOnXkqhRYQMkZCod8sIDFL6TlyaCVvaVyIj7Fi9nBlSBOFaoh2S1Otso3RtAcXpZEY6wxrjQHiO3l+jghX9EzOTr08V9OIMCiPyZiY5ephYAihR0fzvfh0IHdE28e1fUfMODa9ddQVFDJGQsEaDQyfp+xvEy+RlVXVfLWrCHXUc4RojzDPQ0yi8z5RSnu1A/wkyfNzRLiid5967I4IOTjq/KEsz4+LEJrzp0ezPSMR1AoeIGMkdM5xhGoOrXR++YIwqkcn9MxIQH2zDSt2iyUbQRgC84zEJjvvE6VCxX2AnydE8OLU+FnoLQ7PCM9QNDu3+jWYOCaw+tWjiZ6R6iKgaIdDHjJGOgad+wN5Y5UTH5vtIAjaniMfUaiGaI80ewrTCHCVDPge7MYQwXBSjSZvC71AOSP+FnoRwjTe9CiZaIwc+NK57yn0JiBkjBgB845sf1O44XlXjOwKAPjxaDlOVTZwloYgDEb1jGiNEcHCNL5i9pEQAomkhZ6rHv3kaFgsABzhunDrknmS+l9ETc86FPlXKMPzyg8DJzbylsaFbp0SMK53OmQZ+GT7Kd7iEISxqDkjGmNEEiD0Afj3OABieEb8hUBE0Kc/w04Eg0lPjoZZxieTxX3oocCQMWIEsUnAEHGH580d6ew5IgvmuSEEx9YCHFrlnP8iGp5yRkQp7fXncQAE8YywEIgfY4TnucNf/o0QnhEdOUJmGZ97P/Uvi2CQMWIU5/xS2e4Rb3jeRUNyEBdtwdEzddh5soq3OEQksf5p4K2rgPdv5C2JZ3zmjPA2RtgiL8Di5As1BCJymMZfXosA37m/ahrAHDlL9zlmNgFIyQ3f5xgMGSNGkXeuMh2xpR7Y/RFvaVxIjovGhfnKD4QSWYmA2PSysj3yP75yeMNTzogIZZ6A01DSem3c4d0O3tYK1JUp+/5KUnkt9LKsWehFDtPoqZ4yYW5S2UHnfq8p4fscgyFjxCgkydmRdesy4RJZWajms52n0dwqwAAxgjACj54RQcI0LY3K1tuQPIC/Z6TuDABZCcUkZHh+Du+FvqECsDUr+4n++oxwkrG5zpm/5NMTZsJEaeaRG3QpEBUTvs8xGDJGjGT4fGUGxentwnVkndg3E1nJsaisb8HqA6W8xSEiBrGM6jawkKhLzogACZeAZmKvl7k0AP/wAgvRJGa59sHQwnuhZ16RuDQgOs7zc3gbTEzG6AQ/njATdFnjp/JIUMgYMZKkzsDY3yj73/2fUN4Rq0XCFecoZb4UqiF0sWWZ8yQLCDd/CYBvzwh3Y8TPxF6Av2fEX/8OwGnc8ZLRX7UPwN9g0jY889ZtFwj/9223A+v+oexHSBt4BhkjRjPhLuXEWPwzsO9z3tK4wEI13+0vRUVdM2dpCOHZ9YHr7XoBBy76yhnhPcFV9Yz4CNPwNpxYvoivYWrqQs8pvNtYqWzjvQwbBPjrscHx20jI9P28cHtGqjUXmnnjwvMZYYKMEaNJzADGLVT2Vy/mf3WmYUBOMvJzU9Bik/HFz6d5i0OITpNbOW+jYJVYthbA1qTsi9aB1dYMNcSlJ0wTzoRGX7Dv1FdjLN4hEOZhivFl1HH23niaHu2JcBvKDZXK1hIF9Jocns8IE2SMhIPxtwNxqcCZfUqpr0A4e45QAzTCD+4l6qIZI1r5PPUZ4XkhwLwigJ8wjQkJjb5gXoe4NO/P4R0CYbqM8pIvAvCX0VPukifC7Rlhv9EIaQGvhYyRcBCfBkz4nbK/erFSPicIlw3PhdUiYUdhJY6cqeUtDiEy7ARrjVW2bOESBZYvYo11jrkHxOgYyq7mLdGusrnDO4GVLV5xqd6fozY94+S9UXNvfHlGOHtvmB5FMUZ8fZ+CQsZIuBh7qxLjPHsE+Pk93tKodE6OxdT+SnyYElkJn7AwTariTRPOM9Jcp2y1+SKAGKW9ehZQgH9+C3PrCx2mYSXSOhKBuXtGOIdp9Hi6BIWMkXARmwxM+r2yv/YxoFWchFEWqvlk+2nY7eJU/JhCXRlQcYy3FOLT2uTs7cCMkYYKfvJ4oslDJQ3A39sAOA03XwsowF9WXZ4RzgmsuhKBORtMPMI0lYXKqIZDq4CC75XtyS3KYxHoGYniLUC7ZsyvgR+XApUngB1vAqNv5i0RAOD8QVlIiYvCqcoGbDxajgl9/WSAtyf+3kfZ3ndUSTYmPKPNxxDWM+JlARChA+v6p5StrxANoBkrLysVOL7KQsOBeiXtY/HinRyqp0Sat1Gn1xgxyjPS0gC8MNH7bzK+U2jvzwHyjISTmARg0h+U/e//4XQ3ciYu2orZw5WZBR0qkVWr/8pj3MSICFiIJibJmTgoWp8Rr54RTZiGV68fll/hqzcG4NpojMdCyvqM6Crt5ZzAqqeTrejGiMUgL1NloWKIWNz8CV1GAD0mAucsCO39OUDGSLgZdSOQ0hWoPgVsXc5bGpUrRyoN0FbsLkJdkzgJtmFF28DLfQEjXNGeXNXqFMGOk2YPPUYA1wWeV9IlS1o/5zrfz5M0p2Aengd/A+gA/iEQ1TPio5qGt4wBGyMh/pbY99apl+v9v10L3PQVkHtOaO/PATJGwk10HHDevcr+un8CzfW+n28SI7t3Qq/MRNQ32/D17mLe4piD1hgRqP+LkLgYIwI0EfOEv5wRgN/3bHd4kSx+wjQ8ZW2qdRp0vrp18vY6tAbQyZabZ8ThSYz1k6thVJimVsdQvgiDjBEzGHEdkNYDqCsFNr/MWxoAgCRJmMvaw2/vAFU1h1YBr8x03hbtKl80tMaICKWynmA5I+7GiKT1jPAyRhzHl+6cEZgvqzpPJVHfPBXunhGdCaw8QnNmJ7CqLfLJGCECISoGmPJHZf+Hp9o2k+LE5Q5jZMORcpyubOAsTZjZ8qrrbTJGfOMxTCOYMeKpFTzg5m3g9D2zMI17TN8dnp6RWs08FV+oxijnPiO+mp5p9cwjNGd2AqvWM3LhY8r+efeH9p6cIWPELIb9Asjoq8ww2PgCb2kAAHnpCRjXOx2yDHy8vZ0nstYUud4WbWEVDdXtLHCYxtOQPMB1YeIdpgnIM2LyIsoWNH9JtsI0PdPRyRbg852b7RnRGiNjbwV+tw2Y+kBo78kZMkbMwhrlPFg2PCNMz4YrWXv4rSchCzRl2HBY1QCDPCO+aWTGSAr/eLw3vHlGJAFyRmwRkDNSozPvgLcx2uqYP+TTM8Ix3NXa5JyRZLYxkpyjlINn9HGWYEcokS19pJE/F8gaDDRVAT8+y1saAMBFQ7sgPtqKo2V12FFYGfwbVRYC298Sc7LrmQNKNRPg7JBIxohvIqKaxkvOiIVzhQqg8Yz4CdNIEgBHbxGz9VvryDvwZ4zwNkYDSWAF+CQCM8wK09ToDLFFEGSMmInF4vSObHweqCvnKw+ApNgoXDhEcdN+GEp7+PeuAz5dCHx5j0GSGcjy2c595pIWbWEVDZcwDeemV95QPSMeFgDeeS5qzogfzwjAr3197Rll629B4+0ZYf2BomK9P4enZ4T9VqITXOXwhGGeEWZI+gmxRRBkjJjNoEuBnGFKvJt1aeTMXEfPkc93FqGpNcgfSdEOZbv/C2OEMoqWBqWKCQBmPuq8uhIt5CAaajOsLP7twL3hLWcE4N+FVW/OCMDP88QWUX+tw9WreTufSpVWZoz46sDKMU+IzUiKSfT/XCM8I61NzjC/v3yfCCIgY2TRokWQJMnlLyfHqQxZlrFo0SLk5uYiPj4eU6dOxZ49ewwXOqKRJGD6w8r+pped7jaOTOiTiZyUOFQ1tOC7faX+X+ALmzgzeAA4Y6tRccokZVFDDqLBjJGkLDEGz3nCW84IwF9mvTkjgNNgMX0R9WHMaeHdRI4ZI76anvFMYNXTIZZhhGeE/TYt0RHZ9t0bAXtG8vPzUVRUpP7t2rVLfeyJJ57Ak08+iaVLl2Lz5s3IycnBzJkzUVMjRimrMPSbBXQbo8RCf/gXb2lgtUi4wuEdCSlUwxApEVYbW5UkMkb0wtzAyTnGdY00GnUx9RSm4ZznoPYZ0TH+i8lqdrt9vVf0PBd6WdZX2itJmqofgT0jFo2XKVi0lTRmzzIKIwEbI1FRUcjJyVH/OndWZhrIsoynnnoKDz30EObOnYshQ4bgtddeQ319Pd5++23DBY9oJAmY9pCyv+UVoIp/WS1rD7/6wBmU1gQ4Q8d9InFzrefnmU1jNfDqLGWfxVbJGPGPLLt6RngnMHpDTbL1FKbh3KhN9YzoMUaYZ8TkY5Itop70p4VnPoatGYDj4saXMQLwO04D8YwYET5UK2naT8MzIAhj5NChQ8jNzUWvXr0wb948HD16FABQUFCA4uJizJo1S31ubGwspkyZgg0bNnh9v6amJlRXV7v8dQh6TwV6TFJ+bOv+wVsa9M1Kxjnd02Czy/gk0J4j7saHKNNdT2527vearGxFvcoXidYm5wk2IYN/AqMnZNl3mIF3mEZvO3hAYyCb7Blp8lKN5A7PSpVWzYWRr2oagN9xykZ8xJgUpqnRWQUVYQRkjIwdOxavv/46vvnmG7z88ssoLi7GhAkTUF5ejuJiRUHZ2a4Kys7OVh/zxJIlS5Camqr+5eXlBfFvRCCSBEx3eEe2vQ5UHOMqDgBcPUrR/ftbAuw54m6MiDLdlV3dZw0Gzv+zss+7yiISYFfMgLJQ8Q55eKK1yWlQeswZ4Wx0smoaPQmsVk7HZDBhGrNzRtRJ2xJgjfH9XG6eEYceo01KYG2Hc2mAAI2Riy66CFdeeSWGDh2KGTNm4MsvvwQAvPbaa+pzJLcYlizLbe7T8sADD6Cqqkr9KywsDESkyKbHBKDPdOWEufbvvKXB7OFdEBdtwaHS2sB6jmgXL0AgY8RhBOcMc95HYRr/sP4dUfHKoi5imEZrAPvyjPDOGdEVpuF0TOo1Rrg2FNPki/jLj+D1nbOcFrM8I3o750YYIZX2JiYmYujQoTh06JBaVePuBSktLW3jLdESGxuLlJQUl78OxTRHZc3Ot4Gyw1xFSYmLxkVDugAA3t8aQCLrjrdcb4tSUbPtDWWrja3yLvmMBNxzCUQM07AQg7feDrwNqIBKex3PMdOIt7U6F3pPCcBaXMI0JntGWPdVX5U0DF79cNjvRVfOiAEytsOGZ0CIxkhTUxP27duHLl26oFevXsjJycGqVavUx5ubm7F27VpMmDAhZEHbLd1GAf0vUtyfn97O3atw9SilPfznO06joVnHD6bssNLeXovZsW9PNFQAZ48o+6ma0B9v930k4H7FLKI3yV9ZKs9GbbKs8YwI2meE5QQB/q/oeXa0VStp/OSLAPwTWHVV0xjgvVHDNB3YM3Lvvfdi7dq1KCgowE8//YSrrroK1dXVuOGGGyBJEu6++24sXrwYH3/8MXbv3o0bb7wRCQkJmD9/frjkbx9cuBiITQUKNwKrHuEqyrjeGejWKR41Ta34Zo/3XB+VM/vb3idCmEZboTR8nnOft/s+EnBPbOTtZfCErx4jAN/vWWtU6CnttXIwRrS/UX+5GAC/Y6BVR/dVhpVXVRKrptFhMBkapunAOSMnT57EtddeiwEDBmDu3LmIiYnBxo0b0aNHDwDA/fffj7vvvhsLFy7E6NGjcerUKaxcuRLJyX7cgB2d9N7AFc8r+xufBfZ8wk0Ui0XCVQ7vyPtbdeTvNFa2vU+EMA3LF8nKd20XLuJVvmionhEWpuE8tdUT/jwjPMNx2oVeVM8I+41KFv8tzAF+oTo9E3sZvKqSzExgtdvbbQKrDrPdybvvvuvzcUmSsGjRIixatCgUmTomAy8BJt4FrH9aCddk5wOZ/biIcuXIbnjq20PYcKQchWfrkZfuw43rafqwCMYIK39zv3rgXfIZCXgN0wikM38j23l+z9rFUNScETWnRYdXBODoGdExsZfB6zgNR2kve9zdUKw64TRaEylnhAgX0/+s9B5prgXeu75tlYpJ5KUnYEKfDMiyjo6sDZVt77MJ4HX47E5l6371QJ4R/6heB4cxImLSr96cES6eEc1nCusZCaAPCsDPM6JnYi+D6dHsMHFATc905DLZbcCL5wEvTXVNGD64Enh6uLKfkAFE6TQkIwQyRkTCGgVc9aqygJ7ZB3zxe26t1a8ZrSR9frD1JOx2HzKIGqZhV1JdhrveTwms/lFd446Tq4jVNKz/hLdFiudwP2YoWWNdkz+9wTNnRI/nBuBYNhtAzojoJdKAPj3WFAMlu4Hin109z8d/cO4PuTJwOQWHjBHRSM4GrlqmnEx/fk9pF8+BC/JzkBwbhZMVDdhYUO79iR49I5yNEVl2Xq24/2hFDDmIho25xh1XXiLqTJXRyyLFM0zDOhDHp+l7Po9FNJDSY8AZzjH7t61nYi/DyitnxOBBedpKpyZNR3J2XE19ELiYf18qoyFjRER6TgRmOKpqvn4AOLXVdBHiY6yYPTwXgNKR1SueWr/zrqZpbYI6z8L9ypnCNP5hs4asjoWe95wXT7BcAm85Dzw9YMxbGJem7/lc+oyw71inq58ZLbyMEV19RiIgZ0RPAqv2Ak/reWbn2rjUQKSLGMgYEZUJdwIDZys//v/eANSfNV2Ea0YrVTUrdhehqsHLidJTmIZ3nxHtlYX7FRUZI/5x9zqIGKZhi6I/zwgPAyrQRYOH4cTyWvR0iAU0xojZXocA+ozwMOqAwKpp9HhGtBd42n1mpOj1uEUYZIyIiiQBlz8HdOoFVBUC6/5puggj8tIwMCcZjS12fOwtkdWjZ4RzmIadwKwxbfs8UM6If1rdrppF7DOieka8GCMSxwTWQBcNHv0xAvaM8A7TiJwzYrBnRHuB5+IlIc8IwYu4VGdscPN/gOoiUz9ekiQsGNsdAPDmTyfaDs+rOAaUHWz7Qt5hGl9XUyLmP4iG+wIgojdJ9Yz4CdPw6I0SsGeEcka80uonUVkLj0RgIMCcEWYk+zgutcbI/i+An15U/qocfZ/0hv8iDDJGRKfvDKDbucqP8ocnTf/4y8/pioQYKw6X1mJTgVuo6Onhnl/E3Rjx0RFRxIVVNNyvmkUM07BFyptnhOf3HLAxwsMzEqgxwkIgZi/0zDAOJGfETKPOHmQ7eB8yar0hu94HVtyv/NWdUe5LzAxKVNEhY0R0JAmY7himt3U5UGnuVOPkuGjMGaEksr710wl9LxIlTEPGSHC0uuWM8CyT9UarP88Ip/wBwHXSrB6YsWdqAmuAfUa4eUYC0CWP77zhrMP7Jim9P/yhGp4+ZKwtde7nz3X9m/4wkNE3JJFFJaAOrAQnek8Bek4Gjq0Dvv87cNm/Tf34+ef2wDubCrFidxHKagcjM8lP/FYYz4gHtynljPjH5lapIqJnxOYnZ4RXmSegMZR05DkAmpwRE/UbaAdWXsZISzDVNCb+tlmn54QMfV4mPYnAbJTFRU8AY38bmnwRBHlGIoVpDynbHW8BZ4+a+tFDu6VieLdUtNhkfLDVT0dWIEI8IwItrKLhvpiKaMC5e2/cURdPDsaIP0PJHR4zVdQwjeDVNK0BhGl45IwwwyFZ5wRdXcaIwzOS1L7avfuDjJFIocd4oM/5yg/t+3+Y/vELxirDEN/+6YTvjqwA/9Le9U8rWwrTBIf7YipiNY2/ahCuYRo/ISR3uOaMCO4ZCSSBlYtnhA2t02k46AnTMG9Lkk4Dp51AxkgkMfX/KdtdH3geUBdGZg/vguS4KJw4W48fDpd5eIYE9DpP2eUdpmHtmckYCQ73xVREnfkboMarSRcQuGeEXdHzaHqmO2eEkz5bBM8ZUSfo6vWM6DDq2Lk9IT14uSIQMkYiiW5jgKx85WS36wNTPzohJgpXjlSaoL3103HXH/wfjwEPlwDdJyi3eYdp2GyQyfe2fUzEkINo2NwWel4lk77wV9rLo3cHQzWU9HodYl1fZwZMLwGX9podpglmaq+ZYRqHMeI+HdwbquHpQ0Z11o2XIZDtFDJGIglJAs65Ttnf/obpHz/f0XPk232lKDmraXYWFafE7nlejWrxNbhK7wjvjox70zOeIQ9v+Gt6xiusoP1MvZ4RZrTYTDRGVBkjpJpGVwIrhwsNNaSi1xhx6NFbmKa1yfmYnlLhdgRV00Qaw34BrPozULQTKPoZ6DLMtI/un52Mc3umY9Oxs9i34nmoPz920uXVi8Addby8J2NEwKt80XBvB2/VEec2G/dhfu7wGicP+E+udUf1jBi80G9droydT+/V9rHT2x2fLfhsmkD6jPDwhqnJpjqNEYsfPbILKaDDeUbIGIk0EjOAgRcDez8Ftr8JdHnC1I9fMK47jh4rwNSjmiRa1lWQ59Uow25zlvbGJrd9nIwR/7g3FGMnUNmu9BqxCOBQdffeuMO1mibAVuvMaDHSM3JyK/D5Xf6fJ/IwPyCwqb08DNCgq2m8nH/YhVRUnP5Kp3ZCx/pv2wvn/FIxRn5+D5j5V30uTIO4cEgOPkyoBDz1vxIhTKMdkufTM0JhGq+oszYc+tOeFO0tgEXnFX848dcng6c3J2DPSIzr64yg/JBzP703MOjSts+JTgBG3qDv/bhX0wiaM6JW0+gN0+j0jHSwEA1Axkhk0mcakNIVqD4FHPgSGHKlaR8dG2XFlf2jgf0eHhQht6DJcWUhWTy7dimB1T/uYS5txYWtRf8iG07UqbNech64VtME6Rkx0hjR/gazBisXLaEQCWEas42RphrnxF6jckbY+auDhWgASmCNTCxWYMR8ZX/7m6Z//PldGj0/4O+HZgbqlUWykvDrDnlGfGNrdV6NsjCXNslRlLwR1TPi5XrKwjF/KVjPiFELfVOt8Y0RuVXTBFDaa3bOCMsXiUkCYnUaD/5CSc1kjBCRxogFyvbIaqB4l3mfe3ILklY/7PkxEcI0vpJXAcoZ8UeLNoGOeUY0Cz7v5GSGv9kqPA3jQPuMGOkZKTsM/L2v61DN2JTQ35dHmMbW6vydBtL0zCyDKdBKGsC/UdeBwzRkjEQq6b2AgbMByMB/f+mcFBpuVtzvcvOZ1stReNaRY8AzaZBR72jIFt/J8+NkjPiGuYktUc7vU5I0XVgF0ZvqGREwTBNoB1argQmsJzc5vQkM1iwxFHjk4GjzvzzNmXLH7Jb17Jzr7VzjCX/Hpb/zVzuGjJFI5rJngNQ8xSX7yUJA9tOm3Qg04Y1XO92Jf7Zeg2Xrjyl3iOAZYa5Tb02IKGfEN9qGS9owl2jlvWrOiNXz4zzLzAP2jLAEVgN+N+xqffh8YFGV8tepR+jvy+NCgx2LklVfyMtIo04PzAurN0QD+A8l1QTYRK0dQcZIJJOQDlz9muKq3v8FsOEZUz/+3KGDAQDvbT6B6sYWfsO0tPib60A5I77xFrMWITlZi91PAqu/fg7hhKdnJNCOoHrhEabRHoue8r/cCUcisC+Cye/wd1wG2l6+HUHGSKTTbRRw4RJl/9tFwPEN4fus0zuAoh3qzfyeueiXlYS6Zhve21QoRphG/TF7GVwlUpimphj49A5g8394S+LEW8xatJbwfsM0kZgzYsBCXxtgqalejL7QOPA18NFvlMaN3gjU82C2wRRMfoe/c2S4jMkIgIyR9sCYXwNDrwFkG/DV/UpjqnCwznVasJTRF7+erHR3XL7hGFollkDGM0zDfsz+PCMCLKpblytt/b+8x9nbgzfqCdYtRi+SZ8RuVxqwAT4SWDl1YLXbnceW3moaI5ue1TlyDhI7h/5eWoxe6N+dr/RJ+uZB788JdLE32zMSTBmuajzLnr2zdWeUrdHfXwRAxkh7QJKAix5XyllLdgH7PgvP51SdUrZ5Y4GbvgZSu2LOiK7ISIzBqcoGbDxWrTzONUzj58pQJGOEhZQA51Ugb7x1vBQpZ0Qrg7fSXl5eOq1BobvVuoGekaYaZeup+3AoGGmMyLJy4QQA5Ye9P6/JT2WcO6Z7RgKUD3D15HmSkxlgRn9/EQAZI+2FhHRg/EJlf/Xi8OREsOTQC5YAPcYDAOKirbh+vJIg98FOx+M8F6xaP+V2Ig3KY/oEBDJGHIupe8dLtWxSACNOa2CIljOivSrX7RkxcFBeuCa+Ghmmaax07vtKug80J8P0nJEgdO3eQNAdZkzGdDxjhDqwtifGLQR+ehEoOwDs/hAYdo1x791YDVSfVPbd4pnXjeuB59Ycwe7iBiAWglTTRECYhoWUAOdVIG+8NZkS1jPip7TX7O9Ze+wH7BlpUhZnPcma3ghXnwqjvA6NVcDh/7ne1v7PlYXKsXf2CHBys3Kf3sXe6Gqalkag+GdnSNCdyuPKNphqGsCzMdKB+4yQMdKeiE8DJt4J/O+vwJolQP5c44YtvTDJuZ/omhyamRSLq0Z1w/pNp5U7eIVpmuucV1ORkMCqNUa00zp54q17qEg5I1rvjMVbmIazZ8Qao9+oUKtuZOW49GZg6SFcHTyNMEZkGXhxClBR4LyvtQFoqgbiUpVJwi9Nbfs69/wlbxhZIg0AH9wEHPjK//MCMRwsVmVUhWz3bNh3YGOEwjTtjXN/CyRkKr1Hdr5jzHu2NDqvAs653mPJ4m1T+kB2JLDajR6FrhfWhMgS5f1kLIoxIsuCGiNeZoGoehPAGGEyWKK8L/jcckbYXJoA5vdonxtKiEGWg+t9oQcjEoIbq5yGSEZf5/0sz2vzK55f12Oivvc32jNyeruyTc1Thg16+ssbC/SdGdj7ejPsbK1Oz2QHbAdPnpH2RmwSMOn3wMqHgO8eVTq19pzk/3W+YIumNVZptOaBvPQEzBqaBxwAZF5hGu1VhbdFSpSckYYK15NRcw0/WbR484xYBcwZ8ZYvAvAZJw9ojDmdIRrAVdeh/HZaG50hBRHDNOw8EpcK/G4r8MxoZbpwbQnQub/31w37hb73N9IzYrc5Q76/WgWkdAn9PRmWaACNbY9N7SgGo43JCIA8I+2RMb9SrjxqS4DllwBf/F7J+QgWbe8CH67nGyb3AwBYYcfO4+XBf16w6En+EqWtudYrAojjGWlhOSNu1TQWTjkYnmAy+Apn8OozooZpAvCMWKzO4zIUz4g27yhaYGOENfRieV3uvwV3dPcZMdAzUl/uqPiRwlAm7SXkyc4B2lEMHQgyRtoj0fHALd8BI29Qbm95FXhuHHDmYHDvp7MRT15mqrr//Hf7g/usUNATbxUlTLNlmettUYwRr54RQRJYZRn4/C5l31sreIBfzgj7vEA8I4AxvUZYiCY6EbAYfGoPpZpGloHP73Z+byyfi21rS4DVS5SeO6FgVPO4kj3As+cq+4mZxuXdMbz9lrSlzKEkMUcoZIy0V+JSgcv+DfzyM6BTT6D6FPDNA8G9l97plBprft2BIuw+ZdLwPkZAxgjnRfXkJtfbTaKEabzkjLATKK98IEbxz8Cxdcq+5OP0xasUORjPCOD87YSiXzZYTs+E20AJxTNSfhjYukzJYwOA7CHKlnlIKo4Bax/z/Nrcc4KQMUTPyPY3lTAqAGTnh/ZenvBWdq4mH3e8sl6AjJH2T+8pwPUfK27gw98CJzYG/h56W0xr3ObRaMXS73w0NAoHepL3tK59nnkjtY5Oi+zELLpnhBknZg0h84Z2OrWv0COPWSraz+PhGWGGZFiNkSCM+JoiZZuaB1z/CTBjkXKbeVq9tYS/bQNww+f6P0fVYXNoQ0OZvH2mA9e8Hvz7eMPbEMcOXEkDkDHSMUjvDZxznbL/3f8F/np/LdYZmth3jNSKr/cUY39xCLkqgaKnrFFbCsqrTFVbSZMzVNkKY4x4WdCYMWJWQylvsHbngG/vFq+wUtCeEQNCDC1evFpGEEqYhlXLdOoJ9JnmbKjHPCNFO52Pa8nOD6wTqVGJwCxx9ZzrFA+z0XgLIQbT0bUdQcZIR+G8+5Srm2PrgKNrA3vtgRXK1lvvDi2OH9oFA9MBAM+Y6R3Rc2Xh4hnhZIw0VDg/O723shWmAytb0Lx4RliCKw/sdmDnu/qey67kZbt5HrCmWmDX+8q+3u6rDCO6sHoLsRlBKJ6mQoc31t2zys4nrJw1KSe0xFsjSqQLNwHH1zvkCdOwOm/J1Wor+I5XSQOQMdJxSMsDRt2o7K/+m3435pmDzuFNybn+n+/4od04risA4KtdRThUYlI+hJ7BVf7aMZsBy8GJTwfiOyn7whkjbgua2a22PXHgK+DQN87b0T6aYfHwgH34K2DvJ8p+oI3LVM9IY/Cf7y3EZgSqcWcLzLiTZedUaveLmRS380lSFpA3JnQZgeCMptL9wCuaniHJBpbzavGWzxSuhnURAhkjHYnJ9yiLTOFPri2ZfXFGUxXTe4r/5ztOwn06xeLC/BzIMvD3bw4EIWwQ6HFzaisweFXUsPk5yTlOWYUJ0/jJGQllsQyVM/uc++m9gSte9P7cUBemYDj4tXO/99TAXmtEj4ywekaCNOK1c2hGLHB9LNOtt0hyDnD5C8CwecCvvwtYRFgszouNYIxm7blu4l1Or6XRePMyUc4I0WFIzgHG/FrZ1+sdYbkNgy7Vd8Wl+aHde0F/WCRg5d4SbD1+NjiZA0HP4CpJ4t/anMWkk7Kcsgozm8bLghYtgDHCcg8m3wPcuR0YfJn357qE4zgYnUOuDOz5RvTIUPN9whimAQIz7th3FpcK5AxxfUySgPF3OG8nZSnNxea+CHQbFZycoSQCq+e6y4CZfw1fea2e0t4OCBkjHY2JdysLzeltztioL9SyXj/JqwzNQt83KxnXjM4DACz5aj/kUDLc9aC3FTbvnhlanQrnGfEWphHAGKkN4FhkM0AAPoMbA803EN0zEmx40993ptWT3nOML0IpkdabqB8qXpueUZiG6EgkdQaGX6vsb1jq+ljlCeCFycCOt4GK48r+Bkf7d70nV7eF/u4Z/REXbcGW4xX4dl+pAf+AD/S6OVWDiVeYRtNEjp142Ilo08vKsDBt1YiZeKvIiDIgpyFU1InMOo9FMz1g7mGBQPM2DPGMhDFnxGLR5DroXOgbKoHX5yj73r4zF2PEgITRYD0jdjuw7p8OOXQk6oeCt+NSj2e3HUPGSEdk/O3K9uAKoOyQ8/5VjyhNpT65DfjqPmWf/aj1LgBu8dCc1DjcPLEXAODxr/ej1eZlHLcR6L2ysHJufKbt28K8OOxE9NW9yoCuDf/mI5u6oLkbI/Guj/NAb/M9hpm9RrQtzXvpyK1yxwhjL5yeEcB7sy5vHN/g3O92rufndB2pGDlRcc4y91AI1jNSecy53y2EJFo9eDsuw9m0LgIgY6QjktkP6H+Rsv/js877WdUMAFSddH1NoJ4RzQ/tt1P6IC0hGodLa/HhtpNeXmgAeqppAH5D1Bg1GmNEDdO45Yzwks1raS9nz4i2N4vuY9HE1v/MaxOTDFz3UeCvV8NggvYZAQJvfMZCNJn9gekPe35OZj/gngPAH/YZM4wu2OOU/SajEwNPPg4Ub8dlOJvWRQBkjHRUJjgSx3a+4zkk4D5FNmBjxHnCSo2Pxh3TlJHh/1p1CA3NYer7EGiYhptnRHOFzwynlnpXrwMvVy2TwVvTsxZOxkhTtfNkLaJnhHltOvcPbpaJEQnC4faMBDrvhy3wPSb4TgZNzAQS0kOTjRFsuIv9JrsMM0YOX3g7Lr15JTsIZIx0VHpMBLqMUE5gL08D1j2pzIhgVJ5wfX7AC4DrQn/9+B7omhaP4upGLNtQELTYPtEbc1WvTDi1g1dzH3JcZV31Z+d+oO3EjYI1oBLNM8K6dMamADE++otoMStnxNbqDKsFm4RpRIJwOHNGgMCNO/cpvWYQbCLwAUdZdrjzRQDvx6U6MZuMEaIjoS2rqzwB/O8vQFWh9+frHaPt5eopNsqKey9Q+go8v+YIKurCcLXa5Gg976+ahmdpb0ujU86kLGXhYOPjf3pB8zwOnU7tds1sFcGqadY/rWwDac8dSgvzQNjyqtK7B9CfW+WOIcZImBezQPWpGiMmLPCMYD0jPzs6+yaaIKs3PYbbmBQcMkY6Mt1GO/fT+yizGHKGKtU22rhplxH6Xc8+Fvo5w7tiUJcU1DS24un/HWrzeEi0NjkbLPkznHiW9mqn88YkK0ahJ08Oj1Jf7Qncm2eEVy4LG5A3cLb+1xg1xdUfB75y7gdbEWJEh9twN80K1DPCQlfhLpXVEoxnRNvjh/VhCifehk6GO8wmOGSMdGS0J4mek4A5zwK3/gBc8QJw1TLnY6yNvB58nLAsFgkPXTwIAPDGxuM4UGxgm3gW+rDGOFuse4PXeHnAmYsTnaiUSwKunhzWcp9HEzTtVXmUW85IoPkCRsPyD4bM1f8aI3p3BErQxogBnpFwzzYJOEzDmvuZaIwE4xmp1SSvZg00XiZ3mOHp7v0kzwjRYfGVta29Wg8kmdKP12FSv0xcmJ8Dm13GI5/tNq4RmrbSwl/nRJ6eEU8LhvZKNqOP43k8jBHHyVCytvWEmZkM6o4sA9WnlP1AFnsjenfoQnMMJ2QE9xZGTEUOd9Ms9Xejw4h3+c5MDNOoBmgAelQ9OGEajOeOt++aqmkIAq7tngHXBMpArrR0lP89dMkgxEZZsPHoWXy5qygAIX2g9qDQceLjmTPiyZWu3Ven+HII0/hKoONpjOz5SBnQBgRmjBixwOtB62ELdEAew4ipyCKFaXa+C9VIC9f0W0+oBmgAx+m3i5StWR4cb8ng3srqOwhkjHR0JtyphDUm3tn2sQEXK7kkgdTd63Dn56Un4Lapigfgb1/uQ32zAeGSQDL3ueaMeJg/0XeGsk3tDuSNVfZ5eEbYd+ZpQTUrGdQTJ7c49wOZuxJlkgFVp+ksHEzDM8CYnJFwzzYJxBg58aNz38zKsGAMUG1CuRkwz4c3zwjljBAdklmPAvcdBdK6t31s3tvAHVsCcxvqXLRundIHXdPiUVTViOdWHwlAYC8EkrnPNWeELRjJzvumPww8cAq4a4fTVczFGHF8Z+5eMiC4K06jYEm/3hpnecNqwAKvB3bsLdyov+zYHSNzRsIdptFjkDKdzH4qPLJ4Ixijjhlxni7IwoEqI+WMaCFjhHAmUrojSd4f84bOLo1x0Vb8abaSzPrS90dxvDzEsEQgmfsi5Iy4X73GJinD3dRZNTyqaZhnxJMxIkJoK9n389wxwzPS0uCs9EkOoYOoIdU04c4ZCUCfPCppAI3XIQCjztMFQjjxlzNCnhGCMIAATlgX5OdgUt9MNNvsePSLva4P/vQSsOYx/SdnNXNfR3yaa86In8nCzEjhUU3DEhM9lXHzzBnRO43ZHTM8I2yQpDU2sB4o7gSziGop+N5Z2h62ME0AFVWB/B6NJJjmfOHOtXHHkxfM1ur8/ZExQhAGEMBkT0mSsOiywYiySPh2XylWH3CcwMoOAyvuA9YsAQ5+re9z2VwdPc3ZzJxZ4k6jIz7t7epVWM+IpkrBqAoovQS7WKiekTAZI43VwOq/Kfudevqv4vJFqB1uP73DuR+fFrwcvrDqrFSx2515NKYbIwGGu1qbnR5S040RjR5dyurJGCGI0GEnLJ0Lfd+sZNw4oScA4JFP9yhza+rLnU9wH9jnDZZXEJfi/7k8PSPqSdpLbos6q6ZOOambCdOHxUcCK2Tz2+gHG35QPSNh8uYwTwQAXPmf0N4rlJwRu91ZRjvn2fAtqupQRz+GcsNZx+9fMresFwg83KXNzTJrHpSnyimtvJQzQhAGEIQ7/+6Z/dElNQ4nztbj398dcj1BsNizPwJJ3uOZM6KWIHuJpWsXkhaTvSNqmMaTMaLxlpgdqgm2SkTtGhsmzwg75hIyQh+wFkrOiLr4Axh6TWhy+EKv144d4wkZwZc6B0tUgOEudq6JigtuwGEwePqumbyWaCV3rANCxghhLEF06kyKjcJfLssHALz8/VGcKj3jfPDUVn1vEsjVM/ux8/CM1PrxjETHA5LjZ2l2qMZnaS9HY6TyuLIN2DMSxg6ssgwU/azsG+GJCMUzol38w1lGq3pG/OQzaadSm02gRh0L75oVogE8f9cdPHkVIGOEMJogqy5m5efggvxstNplfPjjAecDx9cDG5b6frEsa4wRHScVFobgkTPi70StnVVjdhKrz9Le6LbPM4MTPzm/J5E8I5/fCXz8G2XfiHBaKA3aVv1J2YZ78Y/V6RlRp1LzMEYCaB7X2gy8PF3ZNytEA3jxjDj2A+mj084gY4QwFp2lvZ74y2VDkBQbhTNnz7o+oG2g5Albc2ALViBtrY2GlYEmpHt/Dq/KFTVnxIO7WpL4yFW007nfqWdgr9WbcBkMxzXHZLXOvCZfhNKBtd7xe2Hde8OFGqbxYyT7C0WGk0A8I7WaEPCIBeGRxxOeKqfCPXE5AiBjhDCWEAaq5aTG4b4LBiAJyo/UHutIRmUNlLyhvVLTFabhmMCqJ/+BhZFkkxNF7T48I9r7zTRG2MI34rrAY+mqZyQM8vo7JgOFySrbAm/Gx2SZfI+xMrmjN4E1kAaERhNIuEub8zP1j+GTyR1PlVMdvOEZQMYIYTQhLvTXjeuBXqlK6egJOJpI1fgzRgJMQuNV2qu3jFByLLpmV634yhnR3m+qMRJCD4hw9Rlprne2EDcK7RVxIHkjdpsmLBJmT4TeHjjMGDG74RngDHPo+c7D3bHWG1qDiZXJU84IGSOEwYR49Wy1SJjRWzk57Kx3TECtOuG7xDfQagtenhG9ZYS8PCNqzog3Y4SjZyQYYyRcHVgPrTT2/QA3YyQA46n+rOM4kfT12AkF3dU0mgnaZhOIZ4S1AzDdGNF4P9ixqXpGyBghCGMwIB8j3arET4/Yc513bn/L+wsCvcLhVdrLFlZrrO+SR1ZNI1KfEcC8WS9agu2+CmjkDWHeiyd2f+h6e9gvQn9Pi0WT4xJA3gjLezCjjFZ3NQ1PYySA79zszqsMVn4MOOUkzwhMKqwmOgxGXD07TrCtybn4qu5cXGzdBLmmGF77WwbaFEvtEmu2MaLz5CdqzojenAEjCcWVHhWm0l7WlG/6n4Dcc4Du441536g45XcTiLFnZkhEb8UPzzBNMDkjZhsj1mgAEgAZaGlUxgi0MGOEckaCYsmSJZAkCXfffbd6nyzLWLRoEXJzcxEfH4+pU6diz549ocpJRApG5BU43LzXTB2DjfIQAMDpk8e8Pz9QVz6vahp28vN3la/mjJgsn5oz4uUaJVZnNYWRBNvwDNBMGjbYk8MW2+7jgL7nBz+p151gWsLXmJgsqmehb6p1Hh9cE1j15Iw4wjTBeN1CQZLa6pI8I8EbI5s3b8ZLL72EYcNcOw8+8cQTePLJJ7F06VJs3rwZOTk5mDlzJmpqakIWlogAjJju6jjZ9+zZG+OHDwYANBYfQMn2L4Ej3wENla7P17vIM3jljOiNUTPPjekJrA7jx1uYJuI8I2EIKzVUAOWHlX2jS1eDaXym9q0xwzOiQ5/MUItOBGJNmoKrJSjPiMnGCNBWl1RNE5wxUltbiwULFuDll19Gp06d1PtlWcZTTz2Fhx56CHPnzsWQIUPw2muvob6+Hm+//bZhQhMCE0KfEeV1rU43eFI2Zo07BwDQRzqF7E/nA29cAbw51/U1QXtGOOWMiBqm8TUoD9DfZ8JImkNIMgxHwu0/Bzr3jb7yD6bxmZkNxvQs9P46DIcbtpjbW/2XSIfidQsVb56R6HjPz+8ABGWM3H777bjkkkswY8YMl/sLCgpQXFyMWbNmqffFxsZiypQp2LBhg8f3ampqQnV1tcsfEcGEugA01wBwlLvFp8GaOwL1/a/AfrkHDtq7KvcX73adHNsUbM6IyWGQujJlm5Dh+3m8EljVnBEvYRoenWFVnfloEucNoz0jdpvrQmz0lX8wjc/UBmMmGCOsbNZXLxTW1C9ck4P9EUiJNGsF7+/3GA7cS5BbKWckYGPk3XffxbZt27BkyZI2jxUXKz+M7GzXH0Z2drb6mDtLlixBamqq+peXlxeoSIRIhJoc2uRWcWKNQsL85dh/+Qpc2uwY125rcp2YGmgiGi/PiN4qA+6lvYIksNrtofXQMNozop0mDSixfyMJxngys3LFZaH3YjAFO2HZKAIpkVa9ODxLkB16pJyRwIyRwsJC3HXXXXjzzTcRF+ddaZLbj1SW5Tb3MR544AFUVVWpf4WFhYGIRIhGyJ4Rz4bFnBG5mDW8J6pkJVmw6swpD68RPGdEb5UBt6Znfkp7zU5grS8PrYeG0Z4RvROkgyWonBETK1esmqt2bzrlmYcBuJVI+9Ejy7fhUvVDOSPuBFTau3XrVpSWlmLUqFHqfTabDd9//z2WLl2KAweUAWfFxcXo0qWL+pzS0tI23hJGbGwsYmM77hfQ7mAngmC9Dl5OZpIk4f/mDEHFwU5IlevR9NpcyJ06KRenNUUeX+NdRk4dWPU2g+KeM+ItgVVn0yujCLWHhlpNY5BnhF1Jh4tAjaezR5U/wJyre7bQ25q9L/S8ymW1qCXSPoyRmmLnRHARmrORZyQwz8j555+PXbt2YceOHerf6NGjsWDBAuzYsQO9e/dGTk4OVq1apb6mubkZa9euxYQJEwwXnhCQUKtpfJTbpSZEo1OfMQCALFsJpLL9wJn9zjh15/76PoNXn5EGx0AzvzkjnDwjzDjztvBHO0pYzTJG6nXqyxtGe0a0g9Um/M6Y99TiaYCaL/Z87NxP6Wq8PJ7wl2QbSpM6o9BTIr3/S+d+Rp/wyuMJr56RjmuMBOQZSU5OxpAhQ1zuS0xMREZGhnr/3XffjcWLF6Nfv37o168fFi9ejISEBMyfP984qQlxCbXPiJ8rq9R5L+GndVfjX6v2AQB+c15vTB+QBcR3ArLz9X2GhVPOiN6Mee6eES85I9FBhBFCIdSx6uqgvCYl4TnUHA8WEul2LjDjL6G9lycC7TPCPG3nXGfe6PmoOGUuj7ckW945I4DOqh+H7vpfpJw7zIZ1YWV6ZFsyRozj/vvvR0NDAxYuXIiKigqMHTsWK1euRHIyh5pzwny0pb3BLAD+3LxRsRg7bTbG2wbgX98exNZ1Et4ZmI/ROQFUWxjRCyUY9F79cG8H7+W0EEzpaSiorusgyx21RpWtxdmRNVjY4t9zUuAThPUQaM4I89RkDzVeFm/49YwIEqYBfB+nLP8nd0TYxfGIu+FJOSOhGyNr1qxxuS1JEhYtWoRFixaF+tZEJKK6+GUlzKBnii6glOue2gIc/1G57efK6nfT+2J/cTVW7C7GrW9uxWd3TEJums5Fi1dTMb1xYQuvDqx+qmmCSbAMhVBP0C4DyZpCN0bUBmNhyjEINKxkZo8Rhj/vjVDGiJ5+KBzyRYC2BhPljNBsGsJgtJUYtmZ9xoitBVh+sTP3AwDi0nx/jEXCP68ZjmPl9dhXVI1bXt+C9347HkmxOj7PiJb1waB3/oTEezaNl5yRcHQ09UWoJ2j36o9Q+4KEe/EP2DPCYSCdPxl5TcLVoqtTrIn9WTxBnpE20NRewlhcXOM6F/vaUsUQkSzAgIuB/CuAcbf5fVlCTBRe/uUoZCTGYM/patz6xlY0t+oIbbATqtEzS/yh2zPCqx28n5wR0z0jLMcmSGPEYnHKbETSbbgbjKlNz3Tqly38canhkccT7s263GEGW2KmOfJ4Qk/zOB5eJS1qsrKbZ4Q6sBKEQWivqvWGGbTzNa59B7h6OZAzxOdLGN06JeDVG8cgIcaKHw6X4Z73d8Jul32/KNCTvlHovfrhlsDKZtP4yxkx2RgJxXVtVDmyLIffExGofnm0M3dv1uWOmbNyvOHPM2K3a75LTnKqMro3PSPPCEEYgyRpmooF4BkBgr5KGZ6XhhevH4Voq4TPd57GX7/YC1n2YZCYnYjJ0Hv1oyawkmdE+dwQTtBGdY1trgVa6pV9EXJG7DbnQhZjYnGALxllmb/HAfBfIt1w1nmhFEwzPSOgnJE2kDFCGE+gORmr/qxsQzjJT+7XGf+8ZgQAYPmGY3huzRHvT472c3UXDmwtTk+Hbs8Ir9k0ouSMGNB7wajhfqySJiYpfD00gpk4C3DyjHiQsbHKeT+vXAzA/3HKvCIJGaEnNQcL5Yy0gYwRwngCLZ1lw9A69QrpYy8bnotHLh0MAPj7Nwfw7qYTnp+o5ow0m1c+qz15+y3t5dUO3k/Ts4gM0zDPSIjGiBkJj+yKnnlgfMH+H8lq7gLma6FnTf2iE/nmPvgLJYXaTM8I2nhGHFsrGSMEYRzaXiP+aG12nsTOuy/kj75pYi/cPk3pqPjgx7vwwdaTbZ8UyGRPo9CevP2dcHg3PfM2m4YtRGbl2hjhGYk1KGfEjBkwrNpHz1Rk9v/EJhk/sM8X7s26vMnEE3+eEd7zc4C2Sbb+vJIdADJGCOMJZFhenSPGbIkObky8B+6dNQALxnaHXQbufX8n3tx43PUJXIwRx+dYY5QqD19wawcfQJ8RXzk5RqF2pTQiZ8SgME1SVmjv4wvVGKn2/1xenU59LfQi9BgBnAaT114oHBJ/3XH3jPhrONgBIGOEMJ5AZr9sfF7ZJmUbdoUnSRL+7/IhuHFCTwDAw5/sxis/FDifYI1yymh6Ay8d7mtmrJjuGWHGiJcTolpiK5vTvdbInBE93gZvNFYDq/+m7Iez+oIZI3oMpyZexoiPUB2P6h5PRJJnhOnRX8PBDgAZI4TxqJ4RP4mOFceAH5cq+2l5hoogSRIeuXQwbpuqhGwe/WIvnl192PkEs/MfArnKVz0jnNrB+/OMAObojeVOhDJ3xYhqmpUPOQ2EcFaJqIZTjf/nqs3FTF74fXpGmDHCefSHv9+2UMP8HHqkMA0ZI0QY0LvQV2jCJxc+ZrgYkiTh/gsG4PczlGm+f//mAP7xzQGl7NfsXiOBuLC5tYP3kzOiNVLMqKhRG2iFUH5phNGpnfAazgTW2AC8OLUmhI084atsVpgwjZ/cJhHk1OrRbndWznn77XUAOm6Aiggf/ro0MtgJtefksA2skiQJd83oh7hoC5as2I+lqw+jrLYJS6JiIQHmeUYCifGzEJLp7eD9VNNIkrK4tzaaUxZtRGMqI3rKxCQC9eUOWcJpjKQo29YGpbLJ1ygFXrNVfM2mESEXA/DfZ0SIycIaPWqnh+ud5dUOIc8IYTx62jEDSpgGCG+FgoPfTumDRy8fAosEvLu5EMX1jvwU040RHSdqbqW9rOmZj6szs3qNyDJQ6fCchRIaiTbAM6JdtMJ5rGo/p9lPqIbXbBVfniYRFnnA/zEqQm6LVo/aRP8O7BkhY4QwHj2u8WPrNUmB5pxQrx/XAy9ePxpx0RZUNiuH/tkqHfF5Iwik7JFHaa+sSUr1dUL0V6lgFLved+6HcnwY4RnR5sokhjEsEhXjLPv2lzfCqnvM7nTqKwQiTGmvnz4jQiSwagwmbTI4JbAShIHouRot+N65329WeOXRMHNwNt77zXi0WpSTwZLPtmF/sY5SylAJJE7Nox283QbAUa4rgmfkxEbnfigNtPwtTHqIS3Huh3sAnN68EV6zVaIdx6+nxmwieBwA5+DAhgrPj7OQW3yaKeJ4RHvBps0NYxciHRAyRgjjURsj+TBG2Ml0yh+B3lPCL5OG4Xlp6NdVWVTq6+tx1fM/Yu3BM+H90IByRji0g9e6in1dnekNwYUKOz4u/kdo72OE8cT+12veCH+DMb3lveEe2ueNWB8VPyIkhgLOpF6WV+MO7yF5gGsCvdYjaWYDO8EgY4QwHveJlJ7gdTJ1EBevnDAHd45GbVMrblq2Ca9tOBa+DwzkqpFHzohdp6vYLM+IUceHEWGlJhNLQWN0ND7TThA2O0zjy1gSpbSXGRm1JZ7L43npTouLZ4TKegGqpiHCgZrN7mXBsrUAB75S9k1IXvWI42TwmwldcfR4N3y47SQe+WwPDpfW4pFLByPK6rDTK08AP/wLaPYyL0SyACOvB3pM8P15gcSpeeSMuMStfYVpwtyfxW4H1j4OnNys3A71+DDCeDIzMVNPS/iGCqcnK5w5LJ7w1QtFNM+IvVUZNaENrVWd5H4hBEDTb0h2nls6cPIqQMYIEQ78ufKPfOfcT+8Tfnk84ZAx2t6Ef1w9DP2yk/D41/vxxsbjOFZeh6XzRyI1Phr46UVgy6u+3+vMfuA3q30/p8Vxoo5O8C9boFOPjUDbY8SXq9hXaacRnNwErHX0nJEsQFqP0N7PCOPJVGNER+MzlvMQmxJaQ7hg8GUsiVLaa40G4tMVQ6S21NUY2fqacz8hzPk/vtAmRbPvmjwjBGEw/ur8qxzD66wxQNZAc2RyR7NISZKEW6f0Qa/MRNz97g6sO1SGuc+tx6s3jkGPqkLleYMuBfLGur5HbQmw4Rnn/+MLdmWuZ/GIdSTgNZqQWMvQU9YL+Pd6hYpWl9d9GLorPdThfrIMNFQq+ywxMpzoyRnhWQ2iylejeLG0c5ZE6GzKiO+kGCONVa73s9u9p/Ht6aHtxNxMxghAxggRDvxdPTM36YgF5sjjCQ8VPxfk5+D9W8fj169twZEzdbjiuQ1Ym3EKyQAw5Eog/wrX96hxGCP1ZUp+h69M+EBGhLNFr7FS738TOjadcWs9+UChUOPonzHkSqDP9NDfz59h7I/mOme4zIzqCz0t4ZnHMZQqo2CJ1eSDtNS53hahZJbh7TfE9Np7qpnStEXbQJB5mShMQxAG46+axoxx7P7w4r4f0jUVn94xEb9+bQt2napCbOt2QILnzPvETCWUINuBgrWKa9jlM2KBzgOVEw/zPETp6COgnkirfD8vWGQZKDuk/O9ZgxQDRO+gLiP6dviS6/gGZd+oSodQckaaaoDq08q+JUpfiC1U1DCIL2OEzezhYIxExSkJ1rJNkVFrjIhS2gs4DUf33xBLDI7lnGQLKMdma6MmTNOxl+OO/d8T4cFfnxF29cs1gcz7bJrslDi899txePnVlxBTrFwVv76rAdd3lyFp8yksVmVuSm0J8MYVbd4HADDl/wHTHgjMM+LtRGoUm14CVtyv7A+6FPjFm5owjT9jhIU9wuAZ2f4GcMAxB8aomSvB9hmxtQJP9HEOe4xLM6fsUo8xwn5XPIwRSVLCMI1VbfNGRElgBbwb9EyvsSngTlQcgCqnTB3cM0KlvYTx+EtgLd2nbNN7myOPJ/wkNibEROF3PU6otx/5oQ73vv8zmlvdSgXH3gqkdAWSc13/mJfkyP+UbTCeEZarYDSH/+fcP7Jaif3rDdPE6OyDEZRc3zr3B11qzHvGaJqIybL+19WdcZ06bUa+COCU15d+eYZpAOdCrjWYbK3OJO1Yk3Tli7g0Zev+G1KNEQE8I+y7bjirbDtw91WAPCNEOPDlym+odM4c6TLMNJHaoKNLrKV4FwBgw5BHYdlmxYfbTqKwoh4vXDcK6YmOE8fkPyh/7pw5CDw7RilRPb4hyJyRKmUBNeqKfMsy4JuHnIsGoCx6Z4/6n9jLYF4bow2ltU8Aez9V9q//BMgwqMqKyWtvUcIbeq/a3Y0Bs7p16intVcM0JoSNPKEaTBpjROuBiBPA6+DPMyKCjOyYqitTth08TEOeEcJ41KRBD56RigJlm5StZLzzQk/Jp0PWCeMm4NUbxyA5NgqbCs7iiufW43CpH8+AdjE9+LXzKjtKhzHCTvayzdjcjN0fOg2R1Dxn2Wz1Kf1hmnDls7A5RQDQeYBx7xud4JyCHIjM7saWWW59PaW93D0jHgwmligakyRGVQgzNpq8hWkE8Iyw31Kdo/szhWkIwmB8lVOyFs08k1cBnzkjAJTQhSbRdkr/zvhw4QTkpcfjeHk9rnhuPdYd8tFC3mIFpj+s7NeWAq06F3v35xjZa4Tp/urlwO+2KfkugBLrZ/Mx/C0kZlT6GNnIS5KCC3u5Gy4z/2qYSD5hRo+vqb28PSOeDCamL7PCWf5QvTd1rvcLZYykKVvWN0YEI44jZIwQxuOrBbcIyauAf89IQ4VzgXYsjv2zk/HJwokY3aMTahpbceOyzXjjx2PePyOlm7KtKXZ+jh7PiPakpO2MGips7HzWYCV3JVZzwtbtGUlTtkZ6RtwXDKPd1arMlfpf4/5cs4xn0Ut7Ac+9UJi+mK5548kYsds0eS0ChGnaeEYoTEMQxuIrH+Pn95Qtb2PEX84IW7jj012STjOSYvHWLWMxd2RX2Owy/vTpHiz6bA9sdg/Jkawi5Ohq50lRj2fEYnXOpwnVM3K2APj4VmDFH50GBNO9NvYfaJjGyJwR5oEKF8GElg6tdL2dkGGcPL7QlTPC2RjxND9HOM+IIzdIq0etgSdCLxQ1Z8RhjFACK0EYjLdqGrsNOL5e2U/uYq5M7vjzjPjohRIbZcU/rx6OvllJeOLrA1i+4RhOVTbg3/POQXyMpvFZp57O/TpHiESPZwRQTkytDaEbI/853+kGBpTFgi0Y7ITdXOc8OfvzSrA8H2/j2YOhRmOMaNtkG0Uwxsi+z537UXHmjXZnxoiv5GXmkeAWpvGUM+IwTERIDAU8VyUx4ykqTl9VW7hxPy4pTEMQBuOtmkbrMh19s3nyeMJfzghbIL30u5AkCQun9sWz80ciJsqCVXtLMO+lH3GmRvM/Z/RRmqJp0VNNAzhPlqGGabSGyDnXA1e/5lzgtMaIXs8I00fDWeNCSFrPyK3rjXlPLXqSQt1h31uPiUp1j1mwPB5bk/fJvSz3hz3XbDzpUy1d13l8h5tYD2EakfJFgLbeGQrTEITBaKtptL0d2FWKZBUngdVfmMZPJ9BLhnXB278ei04J0dh5sspRaaM5SY+9ze1zA/CMAMYmsM76P6DPNOdt7dWj3g6s8enOkyZbFEOFGSOD5wCZfY15Ty3ekhm9Ybc7j9WrlwM9xhsvkzdiEpz5DDVewle8p856yhnRa8yahWpoewjTiGqMkGeEIAyGLbiy3fXqWTu7woxulr7wmzPCqn78n/BH90zHRwsnokdGAk5WNGDucxuw8ajDI+HuWTHLGGlpBOrKXe9zj+drG4LpbXpmsTirXZjBFipsOF64FletB0gPrFpF+1ozYXrwlktT4z2EaAqekmxVY0QQz4in71w4Y8Tt2KLSXoIwmChNYp2214hIUz39eUYCrPrplZmIj26bgJHd01Dd2IrrX/kJH2072XbB0HvlyIyCYIyR6iLgH/2Bv7t1uHU3ALVXj4Fc2TIDzQjPiK0F2PBvZT9sxkiAnhH1eRKfvAxfxogsi+MZ0Rojaum6IAuq2im4TvF0AZq5NILktbifB0XRHSfIGCGMJyoWynQ5uOaNiDRIy1/OSBAn/IykWLx9yzhcPDQHLTYZf/jvTrxUmAs5pauSg9B7mv5qg1A8I6e2tm32NMlDl1iWjFp/Vn8HVsCpkxoDPCOVzpb76Dsj9PfzhKeOob5gRjMvD16C43vxVIpsa9bMy+FUueLJGBE1TAPZ6elqrnd7jDMUpnGBjBHCeNh4bMC1okakQVpMPluT55klQU4Wjou2Yum1I3HrFKUD6+IfanB37ltofLAM+OUn+he3UIwR9yvq2U8BMx5p+7xkzRW43jANoLlyN8AzwmRN7w3kjgj9/TwRaJimmbPRHOOjvFfryeNW2uuhUsUmmGckOh7qBRH73gPp9WMGFKZxgYwRIjyoo9s1J0/tFSdvojUlpB6bswXvCrdYJPy/iwbisblDEWWR8OmO07juPz/hbF0AhoUapgmiYsXdGPH2P2g9HHadCayA00AzImfEjCZ4niorfMGexyuc6Mt40noaeXkhPJX2suNUlIVektoaTUx34SgfDwbyjLhAxggRHtSKGs1Cv+djZSuCMRLlwxhprnO69ENYJOed2x3LbzoXyXFR2HK8Apc/ux77i72Ua7oTjGfkyGrgg18Buz5wvd+bO59VCtWXOV3YgXhGvFV76KWpFvjoFtf3DAeeGmD5gk015uYZ8WWMsKv7OH5J4JEQpgE0RigzRkTzjFBprxYyRojw4Ckn48SPjscEOBlYo51dTt3zRphnIToh5Mz7Sf0y8dFtE9CtUzxOnK3HFc9uwBc/n9YhXxDGyMqHgd0fAGePuN6vbb6mJSHDeQKsPuX6ub5g/S3qy/TL5okDK5wt9zPCUNLL8BRW8MWhbxw7vBZ7Hzku6tU9x9+Qdn6OzfH9iRamAdoadVpDTgTcjV2RdMcBMkaI8KBWqzhyRmTZeSU12UMyJQ+8VdRoG54ZcPXZLzsZn90xCZP6ZqKhxYY73t6OxV/tQ6vN7v1F1iCanrES2fPuA658BfjNGuDGr4DUrp6fry3TrSp0fK6OEyKrMPE18VgP2i6uE+8K7b18EWg1DesmOun34ZHHH77kFWFBTUh3GvKslbmInhF3j5gIutMSFevUIyCW7jhAxggRHtQ+Ho4ruYYK5wmr80A+MrnjrdeIzoZngZCeGIPlN43Bb6co5bYvfX8UNyzb5D2PhJ2Y3LvYeqOl0Vl9MW4hMPQqIPccoOdE369jfVAqAzBGfE1lDgTmqRhxXXjbiAeSwKotnQ1XQq0/fMnbIsCCarE6vWPstyKkMeLWnE20nBFJcs1LojANQYQB1muEVdOwE3xcmhhhGsC7ZySAhmcBfZzVggcuGoSl889BQowV6w+X49JnfsDe0x7ySALtM1JT5HhdjLNkVw8sGZXNztGzmPjr0aIXs6qrAgnTNFU7/y9efTy0zejcEeXq3r3XjN4OvmbiNUwjyPkHcM0boTANQYQB92oa3o2aPOGt10iYKzxmD8vFx46OracqG3DVCxvw9W63ypRAc0b+91dlm5QdWGjJvUOsnsXE3esVLGY1wdMmMnoq49bCQnSxqWKVzjJEyBkB2vaaEdIz4tYSXgSvkjtaQ5xKewkiDLhX07DJlIFctYcbf56RMBpOA3KS8entEzGpbybqm2249c2teOZ/hyCzxZLpT9ua3Bcsdu8tWdUb/S5wva0rTGOUZ8Skfh7s/WW7f5lZ2MFgr1hA6K2m4Qn7HbOupiIaIwkZyrbOkWgtpGdEc+z7m5jdziFjhAgP7l4HkRqeMfzljIR59kdagpJHcuOEngCAf646iDvf3YGGZptmGJnOpEtmQJ13X2BCDLjYNVat5+rMUw+ZYNDOKgon0Zpjzl95rwmGqF/cS1K1iLKgtgmBCFhNo4aSHL9n5lXi5fHyhEuYRiBDjgNkjBDhwb2aRkRjxG81TfgXpCirBYsuy8fiK5QGaZ/vPI1rXvwRtbJjsdFtjARpQFksrv9noDkj/sIevmgyqQmexeI0SPzljZjRhM0fPqtpBFlQ3UMgInpG3PvhiOJV0qI99ilMQxBhINrNMyLaxEzAe84Ih/yW+WO7481fj0WnhGjsOlWFZZsdYRc9jbpaGpxhMPccED1oXxNINQ0Q/FTh4xuAw6uUfTMMVL0VNSZ5xXyiXejdjT1m3HP3jLh1YWXHQZRIxgjrFOxujIgapiFjhCCMh/WiUIdURYhnxNbqzL8weUEa1zsDn90xCQOyk1HSpJyYTpXqaCzGQgvWWKVaKVC0JcyBeEaA4EM1G5937qf39v48o2Clw56Gz2mpP6tsWb4BD9jVsmx3ne0EiJOE6W7csWoakcpTmZGtGiMOr5JI3puMPs79tO785BAAMkaI8OBeESCiMeIpZ6TuDABZmbLLYUHKS0/AhwsnoFcX5UR6+GQxHv96P+x2H+EQrScnmCZtyQGGaawxULuTBttrhIVDJt8DdBkW3HsEgjrcz08LexE8eMyQB9p6cphxz/t35G6MyDZlK1KoQS1bPwPYbcofIJbBNPle4PqPgVu+A7qN4S0NV8gYIcJDrFuvBNbaWoS5NAxPnhG2WCVmKc2dOJAUG4Wbpg9RxJAa8fyaI/jNG1tQ29Tq+QVsYQ+2AsQlZ0THiVo7lTlYzwjTs3s1T7jQO0/HrKRaX/jKcRFl2GSMW8t61tZfpIU+sbNyUSHblYoaJqNI4ZCoGKDPdKDrKH6zhgSBjBEiPHj1jAhojLR4MEZ4lnYCsDiMuX5pEmKiLPh2Xymuen4DTlc2tH1yqDkugSawApqKmiB6jWi7nJql5yS3ygpviOLB81ZRw+TTek944D4JWURjxGIFEjKV/dpiMWUkVMgYIcKD+2RPUU7yWvx5RnjiMNpSLY3472/HIzMpFvuLa3D5s+ux62SV63NDNUZScp37UTqrNFRDTmcfFC2NVeZ3OXXvGOoNs3qf+EOdq+I2LK9ZsDANk08NgQi2pGi/dzJGhEawI4doN3jzjIS722YgeMoZYSfX+DTTxXGBeR5szRiRl4ZPbp+AAdnJKK1pwjUv/oiVezRX+GqYJsiE295TgWHzgJG/VObZ6IHl0wQzuZcZBGZ2OY1LVbbui7s7aldYzlVf7Iq+zk2/ohhL7vKJmI8BOJOza4o1MvIJvxK+IWOECA/uOSNNEZIz0iTIyd6tHXy3Tgl4/7bxmNxPmfz72ze34j/rjiodW0Nt1BUdD8x9EbjsGf1dIPV6GjyhDiI00fukznvxZ4wI4sFL9pJwK4x8jkW+4azS8ExUr4M2PCeqjAQAMkaIcBHrNjFTlJOoFk85I6IkCKrGSIt6V0pcNJbdOAbzx3aHLAP/9+U+/OXzvZDVxd3EPBf32SSBwJJIzSyd9tVITIsox6k3/YpSTRPfyVk5U1si7kLvEqYRsPyYUCFjhAgP7leiIiewaj0josjpZWpvlNWCv10+BA9dPAgA8O2PmyEV7VQeNDPpli2W//tL4F1Yv33E9T3MQE/TM7tNs9hzDtO4N+xiMGM5mrMxIkkar0OpMwQiCbakaI06UQ0mAgAZI0S40HpG7HZxrji1eMoZEUVOqzNnxB1JknDLeb3x9LwRmGndrt5fn9zDLOmAriOd+w0V+l8ny848AzOanTH0eEYaKp37vHNG3Bt2MURJYAVcZ7+IutBr+8uImtdCACBjhAgXWs9Cc6044Q8tHj0jJo219wfzjMh250nUjTkjuuKGYUoC6Me2iVjwxj5U1gfZnj1QBs9x7uudnwMoHVBtjnLgyfcYKpJP1FJUHzkjbOGPT+ff1jzZm2dEEGMZcPU6yIIu9Fo9qgYTJbCKCBkjRHiIjne6bFlXU4D/Iq8lEnJGAJ+9PHrGKovrSWsetp+oxNUv/IiiKg+9SMJBfLqyDcQYYfkicWlOz5QZ6AnTiDCXhuGtSZuIxojIZbPMw1RTImbLekKFjBEiPEiSM+6uJuFJ+vtYmIHPnBHeYRqNMeJrGJ1jsbp66ihkp8TiUGktrnh2A/acrvL+GqNwL9/WA4chhACc36et2Tnu3h11WjPnHjOAUz91mnwMWQZaBDk+AY3BVKR48ADxFnqWe9PaQAmsgkPGCBE+WNy9pkjZxiSK1RRJ7SLqoc8I75O9tmW1pqKmDY6r+Zzcnvjwtgnom5WE4upGXP3Cj/jfPj+tz0PFfYy8Hnh1uNV6uryV99aFWCJtJImdAUjKIl9frtzX2uhc9Hl3YAWc32H1aed9Iv2+ASAmAYhNcb1PpPk5hIpgRw7RrmAhmbNHlW1iZ36yeII13HLpwOpYkHh3YJUk50nTl2dE7TGShW6dEvDhbRMwsW8G6pttuOX1LVi2viB8Mrq3BNcD85IlmRwKsUY7JxqzqczuNAnS8AxQ+r2w3wvTWbOm2y1vYxlwfocuxoiAXgd3TxfljAgJGSNE+GBXo+WHla0IV5xamGeE5Yy0NitNnAAx8gbcGp+1wW5zLqwOeVPjo7H8pnPxi9F5sMvAXz7fi0Wf7YHN19TfYFFbggcTpuFg7KnJjF56o7CyXhG8DkDbScPMAxUVL8aCyuSrPum8T0hjxO23LKKMBBkjRBiJdTNGOA+fa0OUm2eEnfQt0UpTJ95EtW185kJdmeK2lywuXqdoqwWPXTkUf7xwIABg+YZjuHHZJpTWBDlh1xuh5IzwMPa0yYyeECVfiOHehVWVTxBjicnXqMlPEnGhb+MZEVBGgowRIoy08YwI4G3Q4p4zok2uFGGctz/PCLvCT8hsc6UsSRJum9oHzy0YibhoC9YdKsNFT63D6v1BtG/3ht6uplrUMA0Hw9RbIzGGqJ4RpjNRuq8yPIUyJQE8Nu64G75kjAgJGSNE+GCxd3blxHv4nDts0WltVBqzsaZXCencRHJBNUa8lPbW+E8GvXhoF3x+xyQMzElGeV0zblq+GYs+24PGFs+9SwIimATWxkply0PH3ua9METzPHgL0/Duvspo04tFEi+BFWhr+IoQ4iLaIOCRQ7Qb3Ht1WDk3knJHu+i01DsbYomQwAhoWsJ7CdOonhzfHqd+2cn45PaJuGliTwBK2ObyZ9fjQLGfoXH+0NO7wx11ECEHHfubp9Pi6M8iymLv3vhMpO6rjEufdu6L6nHQGiOSVQyvJ9EGMkaI8OG+qLOwiChoe560NIiXM6A3TKMj5BEXbcUjl+Zj2Y1jkJkUg/3FNbh06Q94ce2R4JNb3Ych6oGnjvWGaYTxjLjluIh2fAKuhrCoxojWcyiqjERgxsjzzz+PYcOGISUlBSkpKRg/fjxWrFihPi7LMhYtWoTc3FzEx8dj6tSp2LNnj+FCExGCe7dVq2DGiMXiDNW01Il3svcyLE+FlfUGkBg8bWAWVtx1HqYN6IzmVjuWrNiPq17YgCNnAjAoGMFU06gdbnkYI17mvTDY9y+KZ4Qt9IUbHcYyR915Q5scKupCHwkGExGYMdKtWzc89thj2LJlC7Zs2YLp06djzpw5qsHxxBNP4Mknn8TSpUuxefNm5OTkYObMmaipCdEdTEQm7q543vM+PMGMkeZ68U72zHjz1g4+yGTQzsmxePXGMXjiymFIjo3C9hOVuPjpdfjPuqOBeUkCDdNop+LyCIWxsIe3ahrRPCOdNIMP934mXgIr4JocKmr4Q/v7YE3jCOEIyBi59NJLcfHFF6N///7o378//va3vyEpKQkbN26ELMt46qmn8NBDD2Hu3LkYMmQIXnvtNdTX1+Ptt98Ol/yEyIjuGQGcC09LPd98Bk/EpSrbxmrPj4fQWl2SJFwzJg9f//48TO6XiaZWO/7vy334xYs/6s8lCbS0t4Vz0y6mp6YqZ36IlmbBqmlScp0l21UnNJ4bQeQDXBsZNnk5TnmjTZZuNWluExEwQeeM2Gw2vPvuu6irq8P48eNRUFCA4uJizJo1S31ObGwspkyZgg0bNnh9n6amJlRXV7v8Ee0E9wRW0XJGAI1nRMAwjWqMVHp+3ICeHV3T4vH6zedi8RVDkRhjxZbjFbjk3+uw5Kt9qGtq9f3iQI0RZuxJFudcIDOJS3UaxJ5CNSLNfWGMvEHZ1pRojk+Bhk1aI6C1uqgeG8KFgI2RXbt2ISkpCbGxsbj11lvx8ccfY/DgwSguVlzG2dmuV2nZ2dnqY55YsmQJUlNT1b+8vLxARSJExd0zIrIx0lIvnjHCSqEbPQy9k2XDBrtJkoT5Y7tj5R+m4IL8bLTaZbz4/VHMfHItvt5dDFn2EroJNEyjXUx5LBCS5Myv8RSqEc0zAmjKe4vFOz4jCYlqNUQn4G9owIAB2LFjBzZu3IjbbrsNN9xwA/bu3as+LrmdZGRZbnOflgceeABVVVXqX2FhYaAiEaLiHu4QMkyjWVBZaa8oV57MM8L6n2hpqna6nA1qINY1LR4vXj8ar9wwGt06xeN0VSNufXMrbly2GTsKPcjAjE1vg+fcWf8vZctzMWXJjGx4I8PW4pzqGh0PYUjWlCOL1geFwY5TkUnr4f85BFcCNkZiYmLQt29fjB49GkuWLMHw4cPx9NNPIydH+ZG7e0FKS0vbeEu0xMbGqtU57I9oJ7Qp7RU4gbWl3pmbESfIMcgGu3nyjJTuV7ZJOYYv7ucPysaq30/BHdP6ItoqYe3BM7j82fVY8J+NWH+4zOkpSemmbGuK9VXUnDmgbNP7GCpvQKT3cpWFofXuiOR5SO+tbM8c1CRYC2IsMyJhoT//T0p+y3n38ZaE8ELIvitZltHU1IRevXohJycHq1atUh9rbm7G2rVrMWHChFA/hohEIimBtbneuegzI4A3as6IB2Ok+Gdl22VYWD46PsaKey8YgG/uPg9XjuyGKIuE9YfLseA/P+Hy5zbg693FsCVkAsldAMhAyW7fb2i3ASWOMv/Z/wqLzLroMlzZrlnsOgWXJddKVrGa83UeqMjTVAWUOjzQIoWRACA7n7cE/hlyJXDfYWD6w7wlIbwQkDHy4IMPYt26dTh27Bh27dqFhx56CGvWrMGCBQsgSRLuvvtuLF68GB9//DF2796NG2+8EQkJCZg/f3645CdEpk0Cq0AneQbrKdFS50wUFcXtzDw0noyR8iPKtvOAsIrQu3MS/nnNcKy5bypuGN8DsVEW7CysxK1vbsXUf6zG6SiHd6TST3i1/qxzwc/g6BnpM925f2qLc1/b3VSkhEdrNJDRV9lnM55E8twAwOR7lO3gy7mKQUQ2AXWAKSkpwfXXX4+ioiKkpqZi2LBh+PrrrzFz5kwAwP3334+GhgYsXLgQFRUVGDt2LFauXInkZEFKJQlzadMOPlI8I4IYI7EOY6TZQ06GWknTxRRRunVKwF/mDMHvzu+HZesL8ObGEyg824Dd0XbkWoGPNx1AfnYN+md7+a1rQww8Z4NkDQI6DwLO7HM2jQOclTSieR0AJSeo1JmXJ1yYJrMf8Mfj4oxRICKSgIyRV155xefjkiRh0aJFWLRoUSgyEe0Fa5TScp0lWopeTcMSRUUZ6McWHU/5GCH0GAmFzKRY3HfBQNwxrR8+3XEKUauSgRZgT8Fp/P5f3+Pcnum4dmweLhrSBXHRGqNDpIZy2YMVY0Q7o6ZZsIZnWtxLt0WUUZTfDBGxUL0TEV60eSMixeIZbHGsLQVkxyRbYTwjPqpVDOgxEgrxMVbMO7c7pg1TEkKHZ0XBIgGbjp3F79/bibGL/4e/fL4HB0scsotUluppRk2LYK3gtbgbnCLokCAMhhr1E+ElJhGoO6Psi+wZYVfJklUcV72vQXQ1fDwj7kgOg+nSQSkYc+P5eH9LId7dXIhTlQ1Ytv4Ylq0/hnO6p+HOHicwDRBjIWXlsi7GCJvYK1BZLyO1m+ttEQ0mgggR8owQ4UXbbEi0WDfgdHnXlzluC5TAyPq0tNQr1SgMbU8UzsaINpSUkxqH353fD9/fPw3LbxqDC/KzYbVI2H6iEv9dvw8AcKRawsaj5d4bqZlBkgdjhM3/EdFgHnaN620RDDqCMBjyjBDmIeJVJ7vKrC9XtjzalHtDG+JqqnHG5dkiGp3AP2nQQxdWq0XC1AFZmDogC6U1jfhk+ylUbvgJaARO1Ei46aWN6J2ZiAXjeuCqkd2QmmByS/EkD11Y2WRkEY2RuFTgor8DKxw9MsgYIdoh5BkhzEMUj4MW1TNyVtlGC2SMRMU682y0oRptG3jeOlXn03huCZ+VHIffnNcH903rCgDISE9HUmwUjpbV4dEv9mLskm9x/wc78fPJSpMEhjPPpvqU8z7mGRGx4gtwNUzJGCHaIWSMEGFGQANEC8sPYcmrouSLMDxV1KiVNHySV11QjRHfLeElhzE1rFdX/PTg+Vh8xVAMzElGY4sd/91yEpctXY/Ln12PL34+jVZbmMe8q9N7q4GDK5V95hkRdfBbrKYrMM/SaIIIExSmITo28Z1cb4sUpgGUK+KGs64VNQ0OL452NDovEhz6qyv3/Tz2eHwaEmOjMH9sd1x7bh62najAmxtP4Mufi7CjsBJ3vL0dXdPiccOEHvjFmO5IjQ+DcaD9zgvWAv1niR2mAYC+5yvNzzoP5C0JQYQF8owQHZuUXNfbouW1eGp8xrwksQLM0El26K/mtO/nscdTuqp3SZKEUT3S8a9fjMCGB6bj7hn9kJEYg1OVDVj81X5MWPI//PnT3dh9ykMH2lCQJOCCxco+C9WoYRoBy88B5bi8fTPwizd5S0IQYYE8I0THJrEzYIkC7K3KbdE8IzEeeo2wfd7JqwCQ4ugA21ChlMd6M+aqi1yf70ZmUizuntEft07pg892nMZ/fjiKgyW1eP3H43j9x+MY3CUF14zuhjkjuqJTogEGAzNCWRt70T0jAGCha0ei/UJHNxFeRL3SZFisrrkXwnlGPOSMiGSMxKU582w2Puf9edVtPSMe3y7aimvG5OGbu8/DG786F7OHdUGM1YK9RdVY9PlejF38Pyx8ayu+2VOMplabz/fyCfPonNoClB3S5IwIfrwSRDuFPCNEeLn8WeCNK4DzH+EtiXcSM4Hqk8q+qJ6RZkGNEUly9pIp3e/5OXY7UOPwjOicpSNJEib364zJ/Tqjsr4Zn+08jf9uKcTuU9X4alcxvtpVjOS4KFw8pAsuG5GLcb0zYLUEkCydM8S5X/A90ErGCEHwhIwRIrx0HaUM0eJdguoL7aIunGfEIVtTtfM+ti+CMQIAFy4BPvud57b1gNJQzt4CQAqqfX1aQgx+Ob4nfjm+J/aersanO07hs52nUVTViPe2FOK9LYXITIrFzMFZmDEoGxP7ZrrOxfFETCIw6iZg6zLFULIJ3PSMIDoAZIwQ4UdkQwRwTQQV1hjx5BkRIIEV0MjoxRhhIZqkrJBLZwfnpmBwbgr+eOFAbDp2Fp/uOI2vdhWhrLYJ72wqxDubChEXbcHkfp0xc3A2pg/MQmaSFwMj1REyqixUhjoC5BkhCE6QMUIQcZpFncI0gePJe6OFGSM6QzR6sFgkjOudgXG9M/CXy/Kx8Wg5vt1Xgm/3luB0VSNW7S3Bqr0lkCRgZPdOmDEoGzMHZ6NP50RIzDhm+Ss/v+t8YzJGCIILZIwQRESEaQStpgGcHhpvnhHWFyWxc1g+PibKgvP6d8Z5/TvjL5flY29RtWqM7Dldja3HK7D1eAUe/3o/emUmYkr/zjivfybGdRmHNi3uKExDEFwgY4QgtIu6aJ4RT9U0zEsijDHiJ0zD7o8Lf1hJkiTk56YiPzcVd8/oj9OVDfjf/lKs2luCH4+UoaCsDgVldVi+4RiirRJ2xCQiUda0sifPCEFwgYwRghDZM8Im9zaL7BlxyFFfplTOuPfD4Chvblo8rh/XA9eP64Haplb8cKgM3x86g+8PnsHJiga02OEyseD9HSVIiS/GxL6ZSIql0yNBmAX92ghCaM+Im9fBbhfQGNF4PHa+A5yzwPVxQap/kmKjcOGQHFw4JAeyLONYeT2a3uwPVG5Xn7P2aC2+OLwV0VYlJ2Xm4GycPygbXdMEM1IJop1BxghBCF1N4xamaakDIDseE8QYiUtxdrEt2dP28UZmjAhS/QMlnNMrMxG4/hXgpWlAUxXKc6ciL/MS9DjSiOPl9Vh3qAzrDpXhz5/uQX5uCmYMysaMQdnIz02BJZCeJgRB+IWMEYIQOkzjVk3DvCKWKLG8OLP+Bnz9R2fzOC2ieXK0ZPQBHjih7AL4I4D7ZRlHy+rw7d4SfLuvBFuPV2DP6WrsOV2Np/93CJlJsZg6oDOmD8zCpH6ZSIkTdNIvQUQQZIwQhEuYRjBjhMlWUwTIMlC6z3m/SP1b2KyXag8D80Q2RjwgSRL6dE5CnylJ+O2UPiivbcJ3+0vx7b4S/HCoDGW1Tfhg60l8sPUkoiwSzu2VjkuGdcGF+TnI8NbThCAIn5AxQhAunhGBvA0AEJfq3N/5LvDJrcq+QCEPAM6eHR6NETFyRoIlIykWV4/Ow9Wj89DUasOWYxVYvb8Uqw+U4siZOmw4Uo4NR8rx50/3YHzvDNUwMWSgH0F0EMgYIQiRPSOJmc79Qyud+5N+b74svmCekZpiwNbq7GgKOOfSJGWbL5fBxEZZMbFvJib2zcTDswfjeHkdVuwuxpc/F2HXqSr8cLgMPxwuw8Of7MbYXum4aEgOZuXnIDtFMCOXIASDjBGC0HoZQmxXHhbG3wH8uNQZoskeCoy+ia9M7iRlAZIVkG1AXanTOLHbgWqHMeJnYm8k0iMjEbdO6YNbp/TB8fI6fLmrCF/+XIQ9p6tVj8mfPt2Dkd3TcEF+DqYPzELfrCRnF1iCIACQMUIQrp4Rewhj6cMFM5bOOIyRVAEXdYtVafdefVKZgjt8nnJ/XakyJE+yBDUkL5LokZGIhVP7YuHUvjhRXo9v9hTj6z3F2Hq8AttOVGLbiUosWbEf3TrFY9qALEwb2Bnje2ciPsbPUD+C6ACQMUIQ2hbgCen85PCGe+dSbehGJBI6KcbIxuecxggL0SSGPiQvkuiekYBbzuuNW87rjZLqRnyzpxjf7ivFxqPlOFnRgDc2HscbG48jJsqCYV1TMapnJ4zq3gmjenSiJFiiQ0LGCEEAwPz3gbozSqmnaLgnq468kYsYfhl5A/DVvUBDpfO+xiplG9+Ji0gikJ0Sh1+O74lfju+J+uZWbDhcjtUHSrF6fylOVzViy/EKbDleoT6/d2YiRvVQDJPRPTuhd2YS9TUh2j1kjBAEAPSfxVsC77hXoYhoMAFA/wsUY6T6tLMtvIlzaSKBhJgozBicjRmDsyHLMgrK6tRBfluOV+BwaS2OltXhaFkd3t+q9GxJS4jGyO6dMLhLCvplJ6F/djJ6d05EbBSFd4j2AxkjBCE67gu5aI3ZGMldAEhKjsjrlwEjFgCyXXksQst6w4kkSejdOQm9Oyfh6tF5AICKumZsO1GhGig7T1aisr4F3+0vxXf7S9XXWi0SemQkoHt6ArqkxiE7JU7dZiXHoXNyLNITY2ANwaMiyzIaW+xosduRHBtFSbdEWCFjhCBExz1MI1LnVS3WaCBrEFC6Fzi2DjizH5h8r/KYaH1RBKVTYgzOH6TMwwGA5lY79hVVY9uJChwsqcHBklocLKlBTWMrjp6pw9EzdV7fyyIB6YmxyEyKQWp8NGKjrYiNsjj+FK9KfXMr6pptaGhuRV2TTXPbhrrmVsiOyQPRVgkZibHonKy8X1ZyHAbkJGNI11Tk56YgkYYKEiFCRxBBiI7L7JwEsTqvurPgA+DoauDT25UcnDrH1Tx5RoIiJsqC4XlpGJ6Xpt4nyzJKqptwqLQGpysbUFTViJLqRhRXNaKoqhFltU0or2uGXQbKaptQVtsUshwtNhnF1Y0orm5s85gkKXkuQ7umYnTPdEzsm4meGQnkSSECgowRghAdbZgmSvBKi9SuSnjmq/uAlnqgdL9yP+WMGIYkSchJjUNOqncPWavNjrP1zThT04QzNU2obWpFU4sdzTY7mlpsaGq1QwaQGGNFQkwUEmKsSIhVtonqbWXfapFQoXmvstomnKpsxN7T1dh9qgrF1Y04cqYOR87U4ZMdSgfe3NQ4TOibiQl9MjCudwZyaeox4QcyRghCdLSeEbudnxx6kSSlwVn5IeDAl8p9FKYxlSirBVnJSv6IEXRJjUeXVM8GxZmaJuw+XYWdhZX48Ug5tp+oxOmqRnV+j/L6OGeFUI90DOySjGirxRDZIh1ZlsmLBDJGCEJ8tN4QWzM/OQIhsbNijDBE7N9CGELn5FiliduALNw9A2hotmHL8bNYf7gcPx4pw+7T1SiqasQXPxfhi5+VvjOxURYM7JKCoV1TMLRrKvJzUzEgp+MYKHa7jO/2l+Kl74/ilxN6YPawXN4icYeMEYIQHe1Vk72VnxyBcPETwAuTnLdTu/OThTCV+BgrJvfrjMn9OgNQkmR3FlZh6/GzapVQdWMrdhZWYmdhpfq6mCgLhuSmYEReJ4zonoYR3dKQlx7frrwGTa02fLr9NF5adxSHS2sBADZZJmMEZIwQRGRhb+EtgT5S89xud+MjB8GdhJgojO+TgfF9MgAoXoETZ+vx86kq7D5VhV0nq7D7dBVqGlvVtvlYr7w2IzEGI3t0wmhHA7ghXVMjsr9KXVMr3th4HK/+UIDSGiWhODk2CvPHdcdNE3pxlk4MyBghiEggLg1orASyBvOWRB/xaa63yRghHFgsEnpmJqJnZiIuG654BFgDuB0Ob8mOwkrsLapGeV0zVu0twaq9JQDgbJ/vyD+JhPb5q/aW4JFPd+N0lVKJlJMSh5sn9cS153ZHclzHGZHgD0mWWSW5GFRXVyM1NRVVVVVISaGkN4IAABxdA2x/Ezj3N0Deubyl0cfuD4HPfw+c/yfg3Ft4S0NEGI0tNuw5XaV0pz2mhHfK69rmTPVytM8f7TBO+nQWo31+cVUjFn22B1/vKQYAdOsUj7tn9Mdlw3MRE9U+c2NCWb/JGCEIgiCER5ZlHC+vx5bjFWr+ycGS2jbPY+3zmedkeLc0Uycj2+wy3tx4HH//5gBqm1oRZZFwy3m9cef0fu1+QjMZIwRBEESHo6q+BdtOVGCLwzjZUViJxhbX8vcoi4T83BSM6pGOUT06YWSPNK9lyqFS19SK297ahu8PngEAnNM9DUvmDsXAnI6xlpExQhAEQXR4WmxK+3wW1tly/CxKqtt2oM1OicXwbmlK1U5eGoZ2TQ05f6Ostgk3L9+Mn09WIT7aigcvGYQF53YXImRkFmSMEARBEIQbsizjVGWDmney5bgy48dmb7vs9cpMxJCuqRjaNcUxcycVqfH6DJQT5fX45as/4Vh5PdITY/DqjWMwQtPCv6NAxghBEARB6KC+uRW7T1VjR6ES1tnh6Bjria5p8RjUJRmDu6RgUJcU9M9JRrdO8S7lxbtPVeHGZZtRVtuEbp3i8frN56J35ySz/h2hIGOEIAiCIIKkvLYJux2zdnadrMKuU1U4Vdng8bmSBOSmxqN7egLy0uPx1a5i1Da1YlCXFLx20xhkpQg6VdsEyBghCIIgCAOpqm/BvuJq7CtifzU4cqYW9c22Ns8d3zsDL/5yFFI6eN+QUNZvanpGEARBEG6kJkRjXG9l6jBDlmWU1TbjxNk6HC+vx/HyeqTER+O6cd0jsjOsSJAxQhAEQRA6kCQJnZNj0Tk5FqN60PBHI2mfbeAIgiAIgogYyBghCIIgCIIrZIwQBEEQBMEVMkYIgiAIguAKGSMEQRAEQXCFjBGCIAiCILhCxghBEARBEFwhY4QgCIIgCK6QMUIQBEEQBFfIGCEIgiAIgitkjBAEQRAEwRUyRgiCIAiC4AoZIwRBEARBcEW4qb2yLAMAqqurOUtCEARBEIRe2LrN1vFAEM4YqampAQDk5eVxloQgCIIgiECpqalBampqQK+R5GBMmDBit9tx+vRpJCcnQ5Ik3uKYTnV1NfLy8lBYWIiUlBTe4kQspEdjID0aA+nRGEiPxhAuPcqyjJqaGuTm5sJiCSwLRDjPiMViQbdu3XiLwZ2UlBT6sRkA6dEYSI/GQHo0BtKjMYRDj4F6RBiUwEoQBEEQBFfIGCEIgiAIgitkjAhGbGwsHnnkEcTGxvIWJaIhPRoD6dEYSI/GQHo0BhH1KFwCK0EQBEEQHQvyjBAEQRAEwRUyRgiCIAiC4AoZIwRBEARBcIWMEYIgCIIguELGCEEQBEEQXCFjhCAIgugQ2O123iIQXiBjpJ1w4MABbNmyBQD94AiCINyx2WwBz0sh2hKutYb6jLQTRowYga5du+LLL7/kLUpEU19fj++//x65ubmwWq3Iz8/nLRLRwSkqKsL333+P/Px8DBkyhLc4EcsVV1yBJ554Av369eMtSkQTrrWGzMR2wKOPPoqDBw9i165d+PWvf42qqirIsgyyMwPj1VdfxaWXXorrrrsOU6dOxfz583HnnXeqVwGEPnbu3ImioiLeYrQLli1bhquuugo33ngjRo0ahRdffJG3SBHJokWLsHv3bjJEQiSsa41MRDRVVVVydHS0/MUXX8jLly+Xs7Oz5ddff523WBFHdXW1nJSUJC9dulQuLy+Xd+7cKffr109OSkqSJ0+eLC9btkxubW2V7XY7b1GFprq6WpYkSe7du7f81ltvyY2NjbxFiliqqqrk9PR0+d///rdcWVkp//Wvf5V/8YtfyIcOHZJXrlwpf/3113JlZSVvMYWnqqpKjomJkT/99FNZlmV5x44d8mOPPSbPmjVL/tOf/iR/8803dJzqINxrDRkjEc68efPkCy+8UL193333yQkJCfLbb78ty7Is22w2XqJFFEuWLJEvuOACWZadOlu+fLk8ffp0+YorrpD79esnb9++naOEkcHDDz8sjx49Wr755pvlqKgoeerUqfIPP/zQ5nlFRUV0bPrhN7/5jXzRRRept3/++We5S5cu8vDhw+WsrCy5f//+8tNPP81Rwsjg2muvladOnSrLsiwfPXpUHj16tDx06FB53rx5cr9+/eTBgwfLX375JWcpxSfcaw2FaSKYzZs347333sMzzzyj3vfQQw/hoosuwrPPPouSkhJK2NJJYmIimpub0dDQoLoci4qK0KlTJ3z00Ufo3bs3Hn74Ydjtdgp/eaGmpgbl5eW46KKL8Morr2Dbtm2Ijo7GlClTcMstt6CgoAAAUFxcjFtvvRXbt2/nLLG4lJSU4NChQ7j99tvV+5588klkZmbi+eefR0lJCebOnYv77rsPBw8e5Cip2Jw8eRIrV65EYmIidu3ahbvuugvDhw/HZ599hnfeeQc7duzAkCFDcPPNN6O8vJy3uMJiyloTkilDcMNut8uHDx+Wly5dqt5mHDlyRO7Xr588btw4+dixY7xEjCg+/fRTOSEhQX7zzTflsrIyed26dXJUVJT8zjvvyLIsyy+//LI8dOhQub6+nrOk4tLc3CyvXLlSXrduncv9H330kdyvXz+5U6dO8j/+8Q/5lltukXNycjhJGRnU1NTIb7/9trxr1y5ZlmW5vLxcHj16tIuX6fDhw/Lo0aPlzZs38xJTeCoqKuQlS5bIl112mTxo0CC5a9eu8p49e2RZdl7Jf/vtt3L//v3l48eP8xRVWMxaa8gYaWewA2X9+vXy0KFD5f/3//4fZ4kih7/97W9yXFycnJycLPfp00e+6aab1MfWrVsnDxs2TD5x4gRHCSMDdgxqT1qNjY3y448/LiclJcmSJMn/+9//eIkXUTAd1tfXy0eOHHF5bN++fXKfPn3kn3/+mYdoEcWOHTvk+++/X77//vvl0tJSl8e2bdsmDxw4UD5w4AAn6SITo9caKu2NYOx2u0/X2PPPP4/bb78db7zxBhYsWGCiZJGFzWaD1WoFABQWFmLNmjUYOXIk+vfvj+joaLS2tmLBggWora2l0ukQmTZtGjIyMvDBBx/wFiXimT9/PqqqquiYDICCggL06tXL5b5rr70WNTU1+OKLLzhJFfkYsdZEGSwTYQLNzc2IiYnxaojIsgxJknDbbbehvLwcM2bMMFnCyIDpkRkiAJCXl4frr79evV1RUYH//ve/WLNmDTZv3sxDTOEpKirChg0bcPr0aUyfPh35+fnqMahl7dq1WLt2LY4ePcpJUvHxpksAqj6LioqwfPlyrF69Gj/99BNPcYVFq8dp06ap/Vm0hsjp06fxyiuv4Ntvv8XWrVt5iSo0/n7bRq415BmJMCorK/Hss89izpw5GDhwIKKiPNuT7CBpampCbGysyVKKjzc9unubqqur8fXXXyMxMRGXXHIJL3GFpby8HHPmzMGZM2dw9uxZNDc344033sBll13W5rnbtm1DYWEh5syZw0FS8dGry+PHj+OJJ57A0KFDceutt3KSVlz06rGgoACPPvooRowYgTvvvJOTtOKiV4+GrTUhBXkI05k3b54sSZLcv39/+bnnnpNPnTpFvS+CgPRoDHPnzpWvvvpqNd5+7733ygMHDpRra2s5SxZ5kC6NgfRoDGbrkYyRCOLQoUNyfn6+/O6778p33HGHLEmSPGnSJPnzzz+XKyoq1OeVl5fLa9eu5Seo4ASix++++06WZZkMFQ/8/PPPcteuXeWdO3eq9x09elTu2rWr/NFHH6n32e12Svz1A+nSGEiPxhCIHk+ePGnIZ1ITigjizJkzGD9+PPr3749nnnkGhw8fRlxcHObMmYPf/e532Lx5M5qamvDII4/gqaee4i2usASiR1ZX757/QABbt27FoEGD0LlzZ/W+Xr16Ydq0aS65DH/961/x/PPP8xAxYiBdGgPp0RgC0eOzzz5rzIcaYtIQplBXVydv375dbm1tdbl/xYoVcu/eveVOnTrJN998syxJUpteD4QT0qMxHDlyRL7zzjvVfg1Mny+//LI8fPhwWZZl+fjx47IkSfLq1as5SRkZkC6NgfRoDDz0SMZIBOM+K+Xvf/+7LEmSS38Mwj+kx9DRtoLev3+/nJaWJh87dky+4oor5EsvvZSjZJEH6dIYSI/GYJYeqZqmHcD6ZHz99de49NJLUVxcjIyMDN5iRRykx8Dw1OdGlmW0trbioosuQpcuXfDOO+/g1KlTyM7O5iRlZEC6NAbSozHw0CPljEQYNpsNAFBaWorq6moAgNVqRVNTE5577jncfvvttIDqgPQYOhaLRdVjSUkJampqIEkSoqOjMWzYMLz11ltYsmQJnfR1QLo0BtKjMXDRo2E+FiLsaEMJU6dOlTdt2uTy2OHDh3mIFXGQHo3Blx43bdokT5kyhYNUkQnp0hhIj8bAQ48UpokgWBjh4Ycfxscff4xt27ZRQ7MgID0aA+nROEiXxkB6NAYeeiRjRHBkt7baVVVVyMrKwocffojZs2dzlCyyID0ag149auf9EJ4hXRoD6dEYeOuRjBFBqa+vR0JCAgDXg+Ts2bPYsmULZs2axVO8iIH0aAykR+MgXRoD6dEYRNEjGSMC0tLSgoULF2L69Om49NJLkZSUBKCt5Ur4hvRoDKRH4yBdGgPp0RhE0iNN7RWQ+++/H6+88gr279+Pn376CZdffjmmTp3aZlIi4RvSozGQHo2DdGkMpEdjEEmP5BkRjOLiYlxyySWYP38+6uvr8cUXXyAxMRHTp0/H5Zdfro7CPnv2LLZu3YqZM2fSD88DpEdjID0aB+nSGEiPxiCcHg2vzyFC4tChQ/KvfvUredWqVbIsy/KuXbvk3/72t/I555wjz5kzR37ppZfkkpIS+eGHH5a7d+/OWVpxIT0aA+nROEiXxkB6NAbR9EjGiICUlpbKjY2NLvetWLFCnjNnjjxq1Cj5iiuukCVJkj/99FNOEkYGpEdjID0aB+nSGEiPxiCSHskYERTWdEY7zM1ut8svvfSSbLFY5NmzZ/MSLaIgPRoD6dE4SJfGQHo0BlH0SO3gBUGWZdTV1aGgoACAc2S91WqFLMuw2+2QJAmDBg2CxWLB008/zVNcYSE9GgPp0ThIl8ZAejQGUfVICawCUFdXh4cffhjffPMNWltbkZiYiD/84Q+45JJLkJ6erj6vtbUV8+bNAwB88MEHvMQVFtKjMZAejYN0aQykR2MQWY9kjAjAvHnzUFxcjAsuuAB9+/bFypUr8frrr2PEiBH417/+hQkTJrg8X6bMcI+QHo2B9GgcpEtjID0ag9B6NCUYRHjl8OHDcqdOneRt27a1uX/27NlydHS0/Nxzz8myLMstLS2yLLsOMSIUSI/GQHo0DtKlMZAejUF0PVLOCGcsFgtyc3PR0NAAALDb7bDZbOjTpw8+/fRT/PnPf8azzz6LQ4cOISpK6VFHFn9bSI/GQHo0DtKlMZAejUF0PZIxwpnMzEzYbDYsWrQIZWVlsFgssFqtsNlssFgsuPbaa1FZWYkffviBt6hCQ3o0BtKjcZAujYH0aAyi65GMEc4kJydj+fLlOHv2LO644w58+eWXsNvt6lTEPn36ID8/H6dOneIsqdiQHo2B9GgcpEtjID0ag+h6pARWAbDZbHj33Xfx8ssvo7m5GWPGjMHFF1+MYcOG4b///S/++Mc/4siRI+jatStvUYWG9GgMpEfjIF0aA+nRGETWIxkjAnHixAm88sor+PHHH7Fz506Ul5dj7NixuOaaa3DXXXfxFi9iID0aA+nROEiXxkB6NAYR9UjGCGdkTenUu+++i3nz5uHQoUNoaWlBWVkZRowYgZSUFM5Sig/p0RhIj8ZBujQG0qMxiK5HMkY4Y7PZYLVa8be//Q2ffPIJ1q9fj5iYGN5iRRykR2MgPRoH6dIYSI/GILoeyRjhCLNUq6qq0LNnTyxfvhxz5szhLVbEQXo0BtKjcZAujYH0aAyRoEeqpjGRgoICVFZWqreZy+yVV17BpEmThDs4RIX0aAykR+MgXRoD6dEYIlGP5BkxCVmWkZaWhnPOOQd/+tOfMG3aNFgsZAsGCunRGEiPxkG6NAbSozFEqh7Fl7Cd8PPPPyM6OhqlpaWYOXMm5s+fjz179gAAXnzxRWzfvp2zhJEB6dEYSI/GQbo0BtKjMUSsHs3oOU8o/OEPf5BfeOEF+aeffpLz8/PlpKQk+eabb5aTkpLkvXv38hYvYiA9GgPp0ThIl8ZAejSGSNQjGSMmwIYNrVq1Sp44caJ6//Lly+WYmBg5MTFRfuutt+SGhgZeIkYEpEdjID0aB+nSGEiPxhDJeqQwjQmw5KEpU6bAZrPhiSeeAKAMLkpMTMTVV1+Nm266CePGjUNFRQVPUYWG9GgMpEfjIF0aA+nRGCJaj7ytoY7GihUr5AULFsiyLMtdunSR//GPf8iyLMtbt26VH3zwQZ6iRRSkR2MgPRoH6dIYSI/GEGl6pGqaMCFrut0BSsMZm82GxsZGLFiwALt27UJSUhI2btyIpKQkjpKKDenRGEiPxkG6NAbSozG0Fz1SmCaMnDlzBh999BGOHDkCq9WKmJgYpKSk4PLLL0dMTAyefPJJoQ8OUSA9GgPp0ThIl8ZAejSGdqFHfk6Z9s0///lPefTo0XJOTo5ssVjkBx54QE0ukmVZ3rFjh2yz2ThKGBmQHo2B9GgcpEtjID0aQ3vRIxkjYWDXrl1yWlqa/Prrr8tbtmyR33jjDbl///7y+vXreYsWUZAejYH0aBykS2MgPRpDe9Ij5YyEgcsuuwxdu3bF888/DwCoqanBlVdeia5du2LZsmVoaWlBdHR0m1gf4Qrp0RhIj8ZBujQG0qMxtCc9Us6IwRw7dgxlZWWYOXOmel9ycjJuuukmbN26FbIsIzo6GmVlZbjmmmtc5gcQTkiPxkB6NA7SpTGQHo2hvemRjBGDyczMxAUXXIC4uDiX+y+66CJUVlZi165dAIB77rkH+/btQ1paGgcpxYf0aAykR+MgXRoD6dEY2pseKUwTBmpqapCcnKzeZq6yyZMnY+7cubjkkkswaNAgHDx4EH369OEoqdiQHo2B9GgcpEtjID0aQ3vSIxkjYUAbn7Pb7QCUDnj33HMPjh8/jtOnT2PAgAFYtmwZTzGFh/RoDKRH4yBdGgPp0Rjakx7JGDGI1atX48svv8Tu3bsxatQoDBo0CFdccQUSExPV56xbtw5TpkxBeno6SktLI2Kss9mQHo2B9GgcpEtjID0aQ3vVIxkjBrBp0ybMnj0bY8eORVJSEo4dOwZZlpGZmYlbbrkFc+bMAQDU1dXhyiuvxLXXXosbbriBs9TiQXo0BtKjcZAujYH0aAztWY9kjBjApEmTMHbsWDzxxBOwWq0oKSnBF198gc8//xxlZWW46aab8Ktf/QoAUFpaiqysLM4Siwnp0RhIj8ZBujQG0qMxtGs9hreNSfvnzJkz8sSJE+WXXnpJlmXZpfPdnj175Ouvv17u0qWLvHPnTl4iRgSkR2MgPRoH6dIYSI/G0N71KH4gSXAyMzPRp08fvPfee6iqqoIkSbDZbACAwYMH4/XXX0e3bt3w2muvcZZUbEiPxkB6NA7SpTGQHo2hveuRjJEQkB0RrmuuuQZbt27FH/7wB1RXV8NqtaqPAcCMGTNw8OBBtLa28hJVaEiPxkB6NA7SpTGQHo2hI+iRjJEQYCVVl1xyCd577z2sWrUKgwcPxquvvoqKigrU1NSgrKwMK1aswPDhwxEVFcVZYjEhPRoD6dE4SJfGQHo0ho6gR0pgDYHa2lokJSXBbrfDYrGgoKAATz/9NF5++WVkZWUhJycHZ8+eRadOnbBx40be4goL6dEYSI/GQbo0BtKjMXQEPZIxEgSHDh3CW2+9hWXLlmHAgAFYtGgRJkyYoD5eWlqKN954A3V1dRgyZAjGjBmDvLw8jhKLCenRGEiPxkG6NAbSozF0JD2SMRIEEydORHJyMs477zz8+OOPWLt2Lb788ktMnjzZ5XlyBExK5Anp0RhIj8ZBujQG0qMxdCQ9Rl5giTMvvfQSiouL8c033yApKQmAEsf7/PPPMXnyZNWNxraEZ0iPxkB6NA7SpTGQHo2ho+kx8v8DE5FlGR9//DHuuOMOJCUlqRnL8+bNwwcffOByUHzyyScoLCzkKa6wkB6NgfRoHKRLYyA9GkNH1CMZIwFQX1+P1NRUNDU1AYCasXz++eejubkZP/zwAwDgq6++wrx589CpUydusooM6dEYSI/GQbo0BtKjMXRIPZrRWa090draKpeVlcmy7NoBb9asWfKTTz4py7IsDxw4UH7ggQe4yBcpkB6NgfRoHKRLYyA9GkNH0yN5RgLEarUiIyMDgFL7LTvyf8eMGYPNmzfjlVdeQXl5ORYvXsxTTOEhPRoD6dE4SJfGQHo0hg6nR56WUHti3bp1clpamixJkvz+++/zFidiIT0aA+nROEiXxkB6NIb2qkcq7TWI6upqdO/eHfn5+Vi/fj1vcSIW0qMxkB6Ng3RpDKRHY2iveiRjxECam5tRXV2NzMxM3qJENKRHYyA9Ggfp0hhIj8bQHvVIxghBEARBEFyhBFaCIAiCILhCxghBEARBEFwhY4QgCIIgCK6QMUIQBEEQBFfIGCEIgiAIgitkjBAEQRAEwRUyRgiCIAiC4AoZIwRBEARBcIWMEYIgCIIguPL/ASXp4GeClZAuAAAAAElFTkSuQmCC",
-      "text/plain": [
-       "<Figure size 640x480 with 1 Axes>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "plt.plot(nwm_data['Missisquoi River']['streamflow'], label='NWM')\n",
+    "plt.plot(nwm_data['Missisquoi River']['discharge'], label='NWM')\n",
     "# Convert from cubic ft/s (USGS) to cubic m/s (NWM)\n",
     "plt.plot(usgs_data['Missisquoi River']['streamflow'].astype('float') * 0.0283168, label='USGS')\n",
-    "plt.xticks(rotation = 60)\n",
+    "plt.xticks(rotation = 15)\n",
+    "plt.ylabel('Streamflow (m^3/s)')\n",
+    "plt.grid()\n",
     "plt.legend()\n",
     "\n",
     "plt.show()"
@@ -631,26 +345,17 @@
    "id": "31fe6e55",
    "metadata": {},
    "source": [
-    "## GFS forecasted meterological data"
+    "## GFS Forecasted Meterological Data\n",
+    "\n",
+    "In the `forecast-workflow` repository, there are two modules for accessing GFS data, `gfs_fc.py` and `gfs_fc_thredds.py`. The former acessess data from the NOAA Operational Model Archive and Distribution System, or [NOMADS](https://nomads.ncep.noaa.gov/gribfilter.php?ds=gfs_0p25), the later accesses data from the [NCAR THREDDS Research Data Archive](https://thredds.rda.ucar.edu/thredds/catalog/catalog_d084001.html). NOMADS only contains the GFS Data from the last 10 days, while the THREDDS server has GFS data going back to 2015. In this demo, we'll use the THREDDS module to access GFS"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": null,
    "id": "57d1f56d",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'\\nDownload specified GFS forecast data and return nested dictionary of pandas series fore each variable, for each location.\\n\\nArgs:\\n-- forecast_datetime (str, date, or datetime) [req]: the start date and time (00, 06, 12, 18) of the forecast to download. Times are assumed to be UTC time.\\n-- end_datetime (str, date, or datetime) [req]: the end date and time for the forecast. GFS forecasts 16-days out for a given start date.\\n-- locations (dict) [req]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to download forecast data for.\\n-- data_dir (str) [opt]: directory to store donwloaded data. Defaults to OS\\'s default temp directory.\\n-- dwnld_threads (int) [opt]: number of threads to use for downloads. Default is half of OS\\'s available threads.\\n-- load_threads (int) [opt]: number of threads to use for reading data. Default is 2 for GFS, since file reads are already pretty fast.\\n-- return_type (string) [opt]: string indicating which format to return data in. Default is \"dict\", which will return data in a nested dict format:\\n\\t\\t\\t\\t\\t\\t\\t\\t{locationID1:{\\n\\t\\t\\t\\t\\t\\t\\t\\t\\tvar1_name:pd.Series,\\n\\t\\t\\t\\t\\t\\t\\t\\t\\tvar2_name:pd.Series,\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t...},\\n\\t\\t\\t\\t\\t\\t\\t\\tlocationID2:{...},\\n\\t\\t\\t\\t\\t\\t\\t\\t...\\n\\t\\t\\t\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t\\t\\t\\t\\tAlternative return type is \"dataframe\", which smashes all data into a single dataframe muliIndex\\'d by station ID, then timestamp\\n\\nReturns:\\nGFS forecast data for the given locations in the format specified by return_type\\n'"
-      ]
-     },
-     "execution_count": 13,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"\n",
     "Download specified GFS forecast data and return nested dictionary of pandas series fore each variable, for each location.\n",
@@ -662,38 +367,31 @@
     "-- data_dir (str) [opt]: directory to store donwloaded data. Defaults to OS's default temp directory.\n",
     "-- dwnld_threads (int) [opt]: number of threads to use for downloads. Default is half of OS's available threads.\n",
     "-- load_threads (int) [opt]: number of threads to use for reading data. Default is 2 for GFS, since file reads are already pretty fast.\n",
-    "-- return_type (string) [opt]: string indicating which format to return data in. Default is \"dict\", which will return data in a nested dict format:\n",
-    "\t\t\t\t\t\t\t\t{locationID1:{\n",
-    "\t\t\t\t\t\t\t\t\tvar1_name:pd.Series,\n",
-    "\t\t\t\t\t\t\t\t\tvar2_name:pd.Series,\n",
-    "\t\t\t\t\t\t\t\t\t...},\n",
-    "\t\t\t\t\t\t\t\tlocationID2:{...},\n",
-    "\t\t\t\t\t\t\t\t...\n",
-    "\t\t\t\t\t\t\t\t}\n",
-    "\t\t\t\t\t\t\t\tAlternative return type is \"dataframe\", which smashes all data into a single dataframe muliIndex'd by station ID, then timestamp\n",
+    "-- useTCDCInstant (bool) [opt]: wether to use instantaneous var for cloud cover or rolling average value.\n",
     "\n",
     "Returns:\n",
-    "GFS forecast data for the given locations in the format specified by return_type\n",
+    "GFS forecast data for the given locations in a nested dict format where 1st-level keys are user-provided location names and 2nd-level keys\n",
+    "are variables names and values are the respective data in a Pandas Series object.\n",
     "\"\"\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": null,
    "id": "32f5bea4-9c56-469e-89fa-e31a0260aa75",
    "metadata": {
     "scrolled": true
    },
    "outputs": [],
    "source": [
-    "import data.gfs_fc as gfs\n",
+    "import data.gfs_fc_thredds as gfs\n",
     "\n",
-    "start_dt = dt.datetime(2024, 2, 1)\n",
+    "start_dt = dt.datetime(2023, 7, 1)\n",
     "# wothout an hour specified, will default to midnight forecast cycle\n",
     "# fc_start_dt = \"202401016\"\n",
     "\n",
     "# use the same hour as our start datetime, so that we get a full 10 days of fc data\n",
-    "end_dt = dt.datetime(2024, 2, 2)\n",
+    "end_dt = dt.datetime(2023, 7, 2)\n",
     "\n",
     "# define some locations to grab data for. Dictionary value must be lat/long tuple, up to 0.25 resolution\n",
     "stations = {'401': (45.00, -73.25),\n",
@@ -701,12 +399,12 @@
     "\t\t\t'403': (44.75, -73.25)}\n",
     "\n",
     "# define a directory in which to download NWM data\n",
-    "data_directory = \"/data/users/n/b/nbeckage/forecastData/\""
+    "data_directory = \"/netfiles/ciroh/downloadedData/\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": null,
    "id": "e4ea6f0c",
    "metadata": {},
    "outputs": [],
@@ -719,21 +417,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": null,
    "id": "3b8467c4",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['TCDC', 'U10', 'V10', 'T2', 'RH2', 'RAIN', 'CPOFP', 'SWDOWN'])"
-      ]
-     },
-     "execution_count": 32,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# let's check out the meterological variables downloaded - hardcoded for now\n",
     "gfs_data['401'].keys()"
@@ -741,47 +428,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": null,
    "id": "c5d53de6",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "time\n",
-       "2024-02-01 00:00:00+00:00    273.619598\n",
-       "2024-02-01 01:00:00+00:00    273.607239\n",
-       "2024-02-01 02:00:00+00:00    273.689972\n",
-       "2024-02-01 03:00:00+00:00    273.662231\n",
-       "2024-02-01 04:00:00+00:00    273.768982\n",
-       "2024-02-01 05:00:00+00:00    273.668457\n",
-       "2024-02-01 06:00:00+00:00    273.806213\n",
-       "2024-02-01 07:00:00+00:00    273.848785\n",
-       "2024-02-01 08:00:00+00:00    273.742584\n",
-       "2024-02-01 09:00:00+00:00    273.820190\n",
-       "2024-02-01 10:00:00+00:00    273.937866\n",
-       "2024-02-01 11:00:00+00:00    274.017181\n",
-       "2024-02-01 12:00:00+00:00    274.092316\n",
-       "2024-02-01 13:00:00+00:00    274.176514\n",
-       "2024-02-01 14:00:00+00:00    274.258453\n",
-       "2024-02-01 15:00:00+00:00    274.342010\n",
-       "2024-02-01 16:00:00+00:00    274.521729\n",
-       "2024-02-01 17:00:00+00:00    274.560364\n",
-       "2024-02-01 18:00:00+00:00    274.607452\n",
-       "2024-02-01 19:00:00+00:00    274.666534\n",
-       "2024-02-01 20:00:00+00:00    274.444336\n",
-       "2024-02-01 21:00:00+00:00    274.494080\n",
-       "2024-02-01 22:00:00+00:00    274.595276\n",
-       "2024-02-01 23:00:00+00:00    274.711517\n",
-       "2024-02-02 00:00:00+00:00    274.598389\n",
-       "Name: T2, dtype: float64"
-      ]
-     },
-     "execution_count": 17,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "gfs_data['401']['T2']"
    ]
@@ -799,47 +449,31 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": null,
    "id": "3f52afe2",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'\\nA function to download and process NOAA Local Climatological Data data to return nested dictionary of pandas series for each variable, for each location.\\n\\nArgs:\\n-- start_date (str, date, or datetime) [req]: the start date for which to grab LCD data\\n-- end_date (str, date, or datetime) [req]: the end date for which to grab LCD data\\n-- locations (dict) [req]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to get USGS data for.\\n-- return_type (string) [opt]: string indicating which format to return data in. Default is \"dict\", which will return data in a nested dict format:\\n\\t\\t\\t\\t\\t\\t\\t\\t{locationID1:{\\n\\t\\t\\t\\t\\t\\t\\t\\t\\tvar1_name:pd.Series,\\n\\t\\t\\t\\t\\t\\t\\t\\t\\tvar2_name:pd.Series,\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t...},\\n\\t\\t\\t\\t\\t\\t\\t\\tlocationID2:{...},\\n\\t\\t\\t\\t\\t\\t\\t\\t...\\n\\t\\t\\t\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t\\t\\t\\t\\tAlternative return type is \"dataframe\", which smashes all data into a single dataframe muliIndex\\'d by station ID, then timestamp\\n\\nReturns:\\nNOAA Local Climatological Data (total cloud cover and precipitation currently) for the dat range and locations provided\\n'"
-      ]
-     },
-     "execution_count": 18,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"\n",
     "A function to download and process NOAA Local Climatological Data data to return nested dictionary of pandas series for each variable, for each location.\n",
     "\n",
     "Args:\n",
-    "-- start_date (str, date, or datetime) [req]: the start date for which to grab LCD data\n",
-    "-- end_date (str, date, or datetime) [req]: the end date for which to grab LCD data\n",
-    "-- locations (dict) [req]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to get USGS data for.\n",
-    "-- return_type (string) [opt]: string indicating which format to return data in. Default is \"dict\", which will return data in a nested dict format:\n",
-    "\t\t\t\t\t\t\t\t{locationID1:{\n",
-    "\t\t\t\t\t\t\t\t\tvar1_name:pd.Series,\n",
-    "\t\t\t\t\t\t\t\t\tvar2_name:pd.Series,\n",
-    "\t\t\t\t\t\t\t\t\t...},\n",
-    "\t\t\t\t\t\t\t\tlocationID2:{...},\n",
-    "\t\t\t\t\t\t\t\t...\n",
-    "\t\t\t\t\t\t\t\t}\n",
-    "\t\t\t\t\t\t\t\tAlternative return type is \"dataframe\", which smashes all data into a single dataframe muliIndex'd by station ID, then timestamp\n",
-    "\n",
+    "-- start_date (str, date, or datetime) [req]: the start date for which to grab LCD data.\n",
+    "-- end_date (str, date, or datetime) [req]: the end date for which to grab LCD data.\n",
+    "-- locations (dict) [req]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to get data for.\n",
+    "-- variables (dict) [req]: a dictionary of variables to download, where keys are user-defined variable names and values are LCD-specific variable names.\n",
+    "\t\t\t\t\t\t\tCurrently only tested for variables listed in global var_units. \n",
+    "-- units (str) [opt]: specifies unit convention for the data request. Options are 'standard' for standard US units, or 'metric' for metric units.\n",
+    "\t\n",
     "Returns:\n",
-    "NOAA Local Climatological Data (total cloud cover and precipitation currently) for the dat range and locations provided\n",
+    "NOAA Local Climatological Data timeseries for the given locations in a nested dict format where 1st-level keys are user-provided location names and 2nd-level keys\n",
+    "are variables names and values are the respective data in a Pandas Series object.\n",
     "\"\"\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": null,
    "id": "9ae1f125-a20f-42ce-8376-8e0247281b05",
    "metadata": {},
    "outputs": [],
@@ -849,33 +483,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 34,
-   "id": "01ac06ae-a2bd-4236-b0cd-3b22866b87dd",
+   "execution_count": null,
+   "id": "08d974f0",
    "metadata": {},
    "outputs": [],
    "source": [
-    "lcd_data = lcd.get_data(start_date = start_dt,\n",
-    "\t\t\t\t\t\tend_date = end_dt,\n",
-    "\t\t\t\t\t\tlocations = {\"BTV\":\"72617014742\"})"
+    "start = dt.datetime(2025, 7, 1)\n",
+    "end = dt.datetime(2025, 7, 2)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": null,
+   "id": "01ac06ae-a2bd-4236-b0cd-3b22866b87dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lcd_data = lcd.get_data(start_date = start,\n",
+    "\t\t\t\t\t\tend_date = end,\n",
+    "\t\t\t\t\t\tlocations = {\"BTV\":\"72617014742\"},\n",
+    "      \t\t\t\t\tvariables={'preip':'HourlyPrecipitation',\n",
+    "                      \t\t\t   'relhum':'HourlyRelativeHumidity'},\n",
+    "           \t\t\t\tunits='metric')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "id": "a34989a9-55de-4d44-badc-922bdea33252",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['TCDC', 'RAIN'])"
-      ]
-     },
-     "execution_count": 35,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Local Climatological Dataset (LCD) only provides total cloud cover (%) and rain data\n",
     "lcd_data['BTV'].keys()"
@@ -883,33 +520,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "id": "627081d1",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "time\n",
-       "2024-02-01 00:54:00+00:00    1.0\n",
-       "2024-02-01 01:54:00+00:00    1.0\n",
-       "2024-02-01 02:54:00+00:00    1.0\n",
-       "2024-02-01 03:54:00+00:00    1.0\n",
-       "2024-02-01 04:54:00+00:00    1.0\n",
-       "                            ... \n",
-       "2024-02-02 21:54:00+00:00    1.0\n",
-       "2024-02-02 22:31:00+00:00    1.0\n",
-       "2024-02-02 22:54:00+00:00    1.0\n",
-       "2024-02-02 23:54:00+00:00    1.0\n",
-       "2024-02-02 23:59:00+00:00    1.0\n",
-       "Name: TCDC, Length: 82, dtype: float64"
-      ]
-     },
-     "execution_count": 36,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "lcd_data['BTV']['TCDC']"
    ]
@@ -925,82 +539,56 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": null,
    "id": "e5b5da97",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'\\nA function to download and process observational meterological data from UVM FEMC (Forest Ecosysytem Monitoring Cooperative - https://www.uvm.edu/femc/) to return nested dictionary of pandas series for each variable, for each location.\\n\\nArgs:\\n-- start_date (str, date, or datetime) [req]: the start date for which to grab FEMC data\\n-- end_date (str, date, or datetime) [req]: the end date for which to grab FEMC data\\n-- locations (dict) [req]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to get FEMC data for.\\n-- return_type (string) [opt]: string indicating which format to return data in. Default is \"dict\", which will return data in a nested dict format:\\n\\t\\t\\t\\t\\t\\t\\t\\t{locationID1:{\\n\\t\\t\\t\\t\\t\\t\\t\\t\\tvar1_name:pd.Series,\\n\\t\\t\\t\\t\\t\\t\\t\\t\\tvar2_name:pd.Series,\\n\\t\\t\\t\\t\\t\\t\\t\\t\\t...},\\n\\t\\t\\t\\t\\t\\t\\t\\tlocationID2:{...},\\n\\t\\t\\t\\t\\t\\t\\t\\t...\\n\\t\\t\\t\\t\\t\\t\\t\\t}\\n\\t\\t\\t\\t\\t\\t\\t\\tAlternative return type is \"dataframe\", which smashes all data into a single dataframe muliIndex\\'d by station ID, then timestamp\\n\\nReturns:\\nFEMC obsrvational meterological data for the specifed data range and locations, in the format specified by return_type\\n'"
-      ]
-     },
-     "execution_count": 23,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "\"\"\"\n",
-    "A function to download and process observational meterological data from UVM FEMC (Forest Ecosysytem Monitoring Cooperative - https://www.uvm.edu/femc/) to return nested dictionary of pandas series for each variable, for each location.\n",
+    "A function to download and process observational meterological data from UVM FEMC (Forest Ecosysytem Monitoring Cooperative - https://www.uvm.edu/femc/) to return nested dictionary of pandas series fore each variable, for each location.\n",
     "\n",
     "Args:\n",
     "-- start_date (str, date, or datetime) [req]: the start date for which to grab FEMC data\n",
     "-- end_date (str, date, or datetime) [req]: the end date for which to grab FEMC data\n",
-    "-- locations (dict) [req]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to get FEMC data for.\n",
-    "-- return_type (string) [opt]: string indicating which format to return data in. Default is \"dict\", which will return data in a nested dict format:\n",
-    "\t\t\t\t\t\t\t\t{locationID1:{\n",
-    "\t\t\t\t\t\t\t\t\tvar1_name:pd.Series,\n",
-    "\t\t\t\t\t\t\t\t\tvar2_name:pd.Series,\n",
-    "\t\t\t\t\t\t\t\t\t...},\n",
-    "\t\t\t\t\t\t\t\tlocationID2:{...},\n",
-    "\t\t\t\t\t\t\t\t...\n",
-    "\t\t\t\t\t\t\t\t}\n",
-    "\t\t\t\t\t\t\t\tAlternative return type is \"dataframe\", which smashes all data into a single dataframe muliIndex'd by station ID, then timestamp\n",
+    "-- locations (dict) [opt]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to get FEMC data for.\n",
+    "-- variables (dict) [opt]: a dictionary of variables to get; keys can be whatever you want to call the variables, but the values must be the variable abbreviations as seen in default dictionary\n",
     "\n",
     "Returns:\n",
-    "FEMC obsrvational meterological data for the specifed data range and locations, in the format specified by return_type\n",
+    "FEMC obsrvational meterological data for the specifed data range and locations, in a nested dict format where 1st-level keys are user-provided location names and 2nd-level keys\n",
+    "are variables names and values are the respective data in a Pandas Series object.\n",
     "\"\"\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "id": "9c3bedef",
    "metadata": {},
    "outputs": [],
    "source": [
-    "import data.femc_ob as femc"
+    "import data.femc_ob as femc\n",
+    "\n",
+    "start = dt.datetime(2021, 7, 1)\n",
+    "end = dt.datetime(2021, 7, 5)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "id": "0f8991f2",
    "metadata": {},
    "outputs": [],
    "source": [
-    "femc_data = femc.get_data(start_date = start_dt,\n",
-    "\t\t\t\t\t\t  end_date = end_dt)"
+    "femc_data = femc.get_data(start_date = start,\n",
+    "\t\t\t\t\t\t  end_date = end)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": null,
    "id": "cf6e82f5",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "dict_keys(['T2', 'SWDOWN', 'RH2', 'WSPEED', 'WDIR'])"
-      ]
-     },
-     "execution_count": 26,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# taking a look at what meterological vars we have\n",
     "femc_data['CR'].keys()"
@@ -1008,33 +596,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": null,
    "id": "163cb3de",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "time\n",
-       "2024-02-01 00:00:00+00:00    1.900\n",
-       "2024-02-01 00:15:00+00:00    1.853\n",
-       "2024-02-01 00:30:00+00:00    1.813\n",
-       "2024-02-01 00:45:00+00:00    1.743\n",
-       "2024-02-01 01:00:00+00:00    1.635\n",
-       "                             ...  \n",
-       "2024-02-02 22:45:00+00:00   -2.053\n",
-       "2024-02-02 23:00:00+00:00   -2.146\n",
-       "2024-02-02 23:15:00+00:00   -2.237\n",
-       "2024-02-02 23:30:00+00:00   -2.217\n",
-       "2024-02-02 23:45:00+00:00   -2.292\n",
-       "Name: T2, Length: 192, dtype: float64"
-      ]
-     },
-     "execution_count": 27,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
     "femc_data['CR']['T2']"
    ]
@@ -1056,7 +621,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.5"
+   "version": "3.11.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
After some feedback from Mirce last week, I've made some changes to the NWM forcings module:

- `locations` parameter now accepts a `points` dictionary instead of a list. This allows users to label their coordinate pairs, and is consistent with other modules that allow for accepted named coordinate pairs to extract from gridded datasets
- Fixed an error caused by differing CRS coordinate names in some forcings datasets. 
- tweaked the end of `process_nwm_forcings` so that real grid coordinate values are still appended to the nested variables dictionary for each labeled point
- updated `get_data_demo.ipynb` to reflect the most recent versions of our data modules