### PR TITLE
Commits from prod_repo previously unincorporated into main

### DIFF
--- a/data/caflow_ob.py
+++ b/data/caflow_ob.py
@@ -14,7 +14,7 @@ def get_daily(id):
 	try:
 		df = pd.read_csv(locurl, delimiter=r'\s{2,}', index_col= 'Date', header=19, encoding='ISO-8859-1', parse_dates=True, engine='python')
 		print(f'Getting data from {locurl}')
-	except HTTPError as e:
+	except Exception as e:
 		print(f"{e}. {locurl}")
 	return df
 
@@ -23,9 +23,9 @@ def get_instantaneous(id, yearlist):
 	for year in yearlist :
 		locurl = 'https://www.cehq.gouv.qc.ca/depot/historique_donnees_instantanees/'+id+'_Q_'+str(year)+'.txt'
 		try:
-			new_year = pd.read_csv(locurl, delimiter=r'\s{2,}', index_col= 'Date', header=15, encoding='ISO-8859-1', parse_dates=True, engine='python')
+			new_year = pd.read_csv(locurl, delimiter=r'\s{2,}', index_col= 'Date', header=16, encoding='ISO-8859-1', parse_dates=True, engine='python')
 			print(f'Getting data from {locurl}')
-		except HTTPError as e:
+		except Exception as e:
 			print(f"{e}. {locurl}")
 			continue
 		df = pd.concat([df,new_year])

--- a/data/lcd_ob.py
+++ b/data/lcd_ob.py
@@ -217,7 +217,7 @@ def lcdRequest(startDate, endDate, var_list, station_id, units='standard'):
 	returnValue = None
 	# note that 'T00:00:00Z' is added to startDate (and similar appendage) to endDate in order to grab data for UTC time
 	while(returnValue is None):
-		requeststring = 'https://www.ncei.noaa.gov/access/services/data/v1/'+\
+		requeststring = 'https://www.ncei.noaa.gov/access/services/data/v1'+\
 								'?dataset=local-climatological-data'+\
 								'&stations='+\
 									station_id+\

--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -70,7 +70,11 @@ def add_plot(labelled_data, ylabel, title, fc_start, fc_end, row, col, axis):
 		# if there is no time component to the index...
 		if all(d.time() == dt.time(0) for d in data.index) and not data.index.empty:
 			# add a time component
-			data.index = data.index.map(lambda x: x.replace(hour=12)).tz_localize('UTC')
+			data.index = data.index.map(lambda x: x.replace(hour=12))
+			if data.index.tz is None:
+				data.index = data.index.tz_localize('UTC')
+			elif data.index is not dt.timezone.utc:
+				data.index = data.index.tz_convert('UTC')
 		# print("data.index AFTER")
 		# print(data.index)
 		time_sliced_data = data[data.index <= (fc_end + dt.timedelta(days=1))]


### PR DESCRIPTION
These commits are changes you will see in the [prod_repo](https://github.com/CIROH-UVM/forecast-workflow/tree/prod_repo) branch (the HEAD of which is tagged as [FEE_v4](https://github.com/CIROH-UVM/forecast-workflow/tree/FEE_v4)), but were not included when prod_repo was previously merged (#103).

When I re-launched Takis's runs a few weeks ago, I used the prod_repo branch, and encountered a few bugs that I had to squash in order to get the workflow up and running. These three commits reflect those bug fixes.

After this PR is accepted and since I've made a tag for Takis' latest runs ([FEE_v4](https://github.com/CIROH-UVM/forecast-workflow/tree/FEE_v4)), I'd suggest cleaning up the repo a bit by deleting [prod_repo](https://github.com/CIROH-UVM/forecast-workflow/tree/prod_repo) and [prod_on_main](https://github.com/CIROH-UVM/forecast-workflow/tree/prod_on_main).

Similarly to how I've cherry-picked commits from prod_repo onto this new branch for easy merging, I could cherry pick the lone commit from the [peter](https://github.com/CIROH-UVM/forecast-workflow/tree/peter) branch, or we could just tag the peter branch and then get rid of it.