### PR TITLE
Changes for Forecast Elasticity Experiment v5

### DIFF
--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -1943,7 +1943,7 @@ def gencntlfile(theBay, settings):
 		output_start_iter = iterations + 1 	# set output start after max sim iterations
 
 	
-	with open(os.path.join(theBay.template_dir, 'run_aem3d.template.txt'), 'r') as file:
+	with open(os.path.join(theBay.template_dir, 'run_aem3d.template'), 'r') as file:
 		template = Template(file.read())
 
 	# control file is written to runtime directory

--- a/models/aem3d/AEM3D_prep_IAM.py
+++ b/models/aem3d/AEM3D_prep_IAM.py
@@ -1992,7 +1992,7 @@ def gendatablockfile(theBay, settings):
 	hourIter = int(86400 / AEM3D_DEL_T / 24)
 	# Calculate iteration for forecast start: Time between forecast date and spinup start
 	# forecastStartIter = int((settings['forecast_start'] - (settings['spinup_date'] + dt.timedelta(days=1))).total_seconds() / AEM3D_DEL_T) + 1
-	forecastStartIter = int((settings['forecast_start'] - settings['spinup_date']).total_seconds() / AEM3D_DEL_T) + 1
+	forecastStartIter = int((settings['forecast_start'] - settings['spinup_date'] - dt.timedelta(days=7)).total_seconds() / AEM3D_DEL_T) + 1
 
 	logger.info(f'Configuring datablock.xml file')
 	generate_file_from_template('datablock.xml.template',

--- a/models/aem3d/get_args.py
+++ b/models/aem3d/get_args.py
@@ -87,7 +87,7 @@ def check_values(settings_dict, defaults=False):
 			raise ValueError(f"file '{settings_dict['aem3d_command_path']}' not found")
 	
 	# Define valid CQ versions:
-	valid_cqVersions = ['BREE2021Quad', '202406Calibration', 'Clelia', 'islesRF']
+	valid_cqVersions = ['BREE2021Quad', '202406Calibration', 'Clelia', 'islesRF', '202504TakisQuad']
 	# validate
 	if settings_dict['cqVersion'] not in valid_cqVersions and not settings_dict['cqVersion'].startswith("READ_CSV"):
 		raise ValueError(f"'{settings_dict['cqVersion']}' is not a valid CQ version. Valid versions are: {valid_cqVersions}")

--- a/models/aem3d/waterquality.py
+++ b/models/aem3d/waterquality.py
@@ -469,15 +469,15 @@ def genwqfiles (theBay, settings):
 		
 		elif cqVersion == "202504TakisQuad":
 			if bs_name.startswith('MissisquoiRiver'):
-				phosdf['TN'] = np.power(10, (-0.30901 +  0.00485 * logQ +  0.03854 * logQ * logQ)) * p_redux / 1000
+				nitdf['TN'] = np.power(10, (-0.30901 +  0.00485 * logQ +  0.03854 * logQ * logQ)) * p_redux / 1000
 			elif bs_name.startswith('RockRiver'):
-				phosdf['TN'] = np.power(10, ( 0.29419 +  0.15548 * logQ + -0.00616 * logQ * logQ)) * p_redux / 1000
+				nitdf['TN'] = np.power(10, ( 0.29419 +  0.15548 * logQ + -0.00616 * logQ * logQ)) * p_redux / 1000
 			elif bs_name.startswith('PikeRiver'):
-				phosdf['TN'] = np.power(10, (-0.08346 +  0.64793 * logQ + -0.20651 * logQ * logQ)) * p_redux / 1000
+				nitdf['TN'] = np.power(10, (-0.08346 +  0.64793 * logQ + -0.20651 * logQ * logQ)) * p_redux / 1000
 			elif bs_name.startswith('MillRiver'):
-				phosdf['TN'] = np.power(10, (-0.03505 +  0.15320 * logQ +  0.02576 * logQ * logQ)) * p_redux / 1000
+				nitdf['TN'] = np.power(10, (-0.03505 +  0.15320 * logQ +  0.02576 * logQ * logQ)) * p_redux / 1000
 			elif bs_name.startswith('JewettStevens'):
-				phosdf['TN'] = np.power(10, ( 0.52674 +  0.06028 * logQ + -0.03018 * logQ * logQ)) * p_redux / 1000
+				nitdf['TN'] = np.power(10, ( 0.52674 +  0.06028 * logQ + -0.03018 * logQ * logQ)) * p_redux / 1000
 			else:
 				raise Exception(f'CQ Equation for baysource={bs_name} not found for cqVersion={cqVersion}') 
 		


### PR DESCRIPTION
Mostly bugs picked up and squashed during the process of launching the latest version of hindcast runs.

Most notable change that is _not_ a bug: AEM3D will now start the forecast period (i.e. actually predicting data) 7 days prior to the stated forecast start date. For example, if a forecast start date is '2020-06-07 00:00:00', the first timestamp in the AEM3D forecast outputs will be '2020-06-01 00:00:00' and the last timestamp will be '2020-06-14 00:00:00', assuming a forecast duration of 7 days.