### PR TITLE
Initial Zensical documentation website + Google-style docstrings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: Documentation
+on:
+  push:
+    branches:
+      - master
+      - main
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/configure-pages@v6
+      - uses: actions/checkout@v7
+      - uses: actions/setup-python@v6
+        with:
+          python-version: 3.x
+      - run: pip install zensical
+      - run: zensical build --clean
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: site
+      - uses: actions/deploy-pages@v5
+        id: deployment

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,9 +1,5 @@
 name: Documentation
-on:
-  push:
-    branches:
-      - master
-      - main
+on: workflow_dispatch
 permissions:
   contents: read
   pages: write

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__
 *.vscode
 *.log
 *.ipynb_checkpoints/
+site/

--- a/README.md
+++ b/README.md
@@ -1,8 +1,15 @@
-# forecast-workflow
-CIROH @ UVM Forecast Workflow Model and Data Preparation Components
+# Welcome to CIROH @ UVM forecast-workflow Repository
 
-## Repository workflow for developer's reference
-### 1. `models/aem3d/AEM3D_prep_worker.py`
-This is the file that loads `models/aem3d/AEM3D_prep_IAM.py` as a module, which sets up logging and then runs `AEM3D_prep_IAM()` to setup data and get all inputs ready for the model run. Note that `AEM3D_prep_IAM()` *does not* download any data by default.
-### 2. `models/aem3d/AEM3D_worker.py`
-This file runs the AEM3D model with logging. See `main()` to see exactly what is going on, but so far it looks like the only settings being directly passed to `aem3d_openmp` besides an empty list `args` is `_iter=True`. I'm not sure how the model is inheriting all of the setup done in step 1. 
+This repository was developed by researchers at CIROH @ UVM to run multi-year, multi-scenario cyanobacteria harmful algal bloom (cyanoHAB) forecasts for Lake Champlain. It orchestrates the acquisition and preprocessing of meteorological and hydrological data, computes nutrient loading via CQ relationships, and drives the AEM3D 3D hydrodynamic and water quality model to produce forecasts of lake conditions.
+
+## Data acquisition modules
+
+The most broadly useful part of this repository to other researchers is the collection of data-acquisition modules under [`data/`](data/). Each module wraps the details of a specific upstream data source behind a common interface, returning ready-to-use time series for locations of interest. Sources currently supported include:
+
+- **Streamflow**: NOAA's National Water Model (NWM) forecasts and retrospective runs, USGS streamgages, and CEHQ (Quebec) streamgages
+- **Meteorology**: NOAA GFS and CFS forecasts, NOAA Local Climatological Data (LCD) observations, NWM forecast forcings, and AORC gridded meteorology
+- **Water quality**: FEMC tributary monitoring data and Sentinel-3 satellite imagery
+
+If you're building a similar hydrology or water-quality forecasting pipeline and need working code to pull one of these data sources, these modules are a good place to start.
+
+For full documentation of each module see the [documentation site](https://ciroh-uvm.github.io/forecast-workflow/).

--- a/data/archive_fcns.py
+++ b/data/archive_fcns.py
@@ -3,6 +3,12 @@ import os
 import sh
 
 def remove_directories(dirs):
+	'''
+	Recursively deletes each directory in the given list (via `rm -rf`).
+
+	Args:
+	-- dirs (list of str) [req]: absolute paths of the directories to delete.
+	'''
 	for dir in dirs:
 		print(f'Deleting {dir}')
 		sh.rm('-rf', dir)
@@ -10,16 +16,27 @@ def remove_directories(dirs):
 
 
 def archive_directories(source_dirs, destination_dir):
+	'''
+	Copies each source directory into a destination directory (via `rsync -a`, preserving attributes).
+
+	Args:
+	-- source_dirs (list of str) [req]: absolute paths of the directories to archive.
+	-- destination_dir (str) [req]: absolute path of the directory to archive them into.
+	'''
 	for source_dir in source_dirs:
 		print(f'Archiving {source_dir}')
 		sh.rsync('-a', source_dir, destination_dir)
 		print(f'Successfully archived {source_dir} in {destination_dir}')
 
-### Moves all forecast data except those from the past n days to a specified archive directory
-# -- source (str) [required]: absolute path to the directory in which the forecast data are located
-# -- destination (str) [required]: absolute path to the directory in which the forecast data will be archived
-# -- past_n (int) [optional]: the number of past days to keep in source directory. current date included in count.
 def archive_forecasts(source, destination, past_n = 10):
+	'''
+	Moves all forecast data except those from the past n days to a specified archive directory.
+
+	Args:
+	-- source (str) [req]: absolute path to the directory in which the forecast data are located.
+	-- destination (str) [req]: absolute path to the directory in which the forecast data will be archived.
+	-- past_n (int) [opt]: the number of past days to keep in the source directory. Current date included in count. Defaults to 10.
+	'''
 	print("Forecast archive process initiated")
 	today = datetime.today()
 	past5 = ['7dayforecast-'+(today - timedelta(days=i)).strftime('%Y%m%d') for i in range(past_n)]
@@ -36,11 +53,15 @@ def archive_forecasts(source, destination, past_n = 10):
 	print('Forecast directory deleting complete')
 
 
-### Moves all gfs data except those from the past n days to a specified archive directory
-# -- source (str) [required]: absolute path to the directory in which the gfs data are located
-# -- destination (str) [required]: absolute path to the directory in which the gfs data will be archived
-# -- past_n (int) [optional]: the number of past days to keep in source directory. current date included in count.
 def archive_gfs(source, destination, past_n = 5):
+	'''
+	Moves all GFS data except those from the past n days to a specified archive directory.
+
+	Args:
+	-- source (str) [req]: absolute path to the directory in which the GFS data are located.
+	-- destination (str) [req]: absolute path to the directory in which the GFS data will be archived.
+	-- past_n (int) [opt]: the number of past days to keep in the source directory. Current date included in count. Defaults to 5.
+	'''
 	print("GFS archive process initiated")
 	today = datetime.today()
 	past5 = ['gfs.'+(today - timedelta(days=i)).strftime('%Y%m%d') for i in range(past_n)]
@@ -57,11 +78,15 @@ def archive_gfs(source, destination, past_n = 5):
 	print('GFS directory deleting complete')
 
 
-### Moves all nwm data except those from the past n days to a specified archive directory
-# -- source (str) [required]: absolute path to the directory in which the nwm data are located
-# -- destination (str) [required]: absolute path to the directory in which the nwm data will be archived
-# -- past_n (int) [optional]: the number of past days to keep in source directory. current date included in count.
 def archive_nwm(source, destination, past_n = 5):
+	'''
+	Moves all NWM data except those from the past n days to a specified archive directory.
+
+	Args:
+	-- source (str) [req]: absolute path to the directory in which the NWM data are located.
+	-- destination (str) [req]: absolute path to the directory in which the NWM data will be archived.
+	-- past_n (int) [opt]: the number of past days to keep in the source directory. Current date included in count. Defaults to 5.
+	'''
 	print("NWM archive process initiated")
 	today = datetime.today()
 	past5 = [(today - timedelta(days=i)).strftime('%Y%m%d') for i in range(past_n)]

--- a/data/caflow_ob.py
+++ b/data/caflow_ob.py
@@ -10,6 +10,15 @@ from urllib.error import HTTPError
 # 	030425 : Rock
 
 def get_daily(id):
+	"""
+	Downloads Canadian daily streamflow observation data for a single station from the CEHQ (Centre d'expertise hydrique du Québec) historical data archive.
+
+	Args:
+	-- id (str) [req]: CEHQ station ID (e.g., '030424' for Pike, '030425' for Rock).
+
+	Returns:
+	A pandas DataFrame of daily streamflow records for the station, indexed by date, with columns matching the raw CEHQ file (including 'Débit (m³/s)').
+	"""
 	locurl = 'https://www.cehq.gouv.qc.ca/depot/historique_donnees/fichier/'+id+'_Q.txt'
 	try:
 		df = pd.read_csv(locurl, delimiter=r'\s{2,}', index_col= 'Date', header=19, encoding='ISO-8859-1', parse_dates=True, engine='python')
@@ -19,6 +28,16 @@ def get_daily(id):
 	return df
 
 def get_instantaneous(id, yearlist):
+	"""
+	Downloads and concatenates Canadian instantaneous (15-minute frequency) streamflow observation data for a single station across one or more years from the CEHQ historical data archive.
+
+	Args:
+	-- id (str) [req]: CEHQ station ID (e.g., '030424' for Pike, '030425' for Rock).
+	-- yearlist (list of int) [req]: years to download instantaneous data for. Years with a failed request are skipped.
+
+	Returns:
+	A pandas DataFrame of concatenated instantaneous streamflow records across all requested years, indexed by date/time.
+	"""
 	df = pd.DataFrame()
 	for year in yearlist :
 		locurl = 'https://www.cehq.gouv.qc.ca/depot/historique_donnees_instantanees/'+id+'_Q_'+str(year)+'.txt'

--- a/data/cfs_fc.py
+++ b/data/cfs_fc.py
@@ -307,11 +307,13 @@ def process_ncss(ds, variables, locations):
 
 def remap_to_cfs_coords(locations):
 	'''
-	Given a standard location dictionary, will  return a tuple containing two paired lists of -90 - 90 latitudes and 0-360 longitudes
-	
+	Remaps a standard location dictionary's longitudes from the -180-180 convention to the 0-360 convention that CFS uses.
+
+	Args:
+	-- locations (dict) [req]: a dictionary mapping location names to (lat, lon) tuples, with longitudes on the -180-180 scale.
+
 	Returns:
-	--lats: list of latitudes
-	--lons: corresponding list of longitudes
+	A dictionary mapping the same location names to (lat, lon) tuples, with longitudes remapped to the 0-360 scale. Latitudes are unchanged.
 	'''
 	# function to convert longitude on the -180 to 180 scale to 0 to 360 (Higher longitude makes east side of boundary box, lower value is west boundary)
 	map_function = lambda lon: 360 + lon if (lon < 0) else lon

--- a/data/gfs_fc.py
+++ b/data/gfs_fc.py
@@ -100,12 +100,31 @@ def append_timestamp(sta_dict, loc_dict, loc_dfs):
 			sta_dict[stationID] = df_to_append
 
 def dict_to_csv(loc_dict={}, location_dataframes={}):
+	"""
+	Writes each station's processed GFS dataframe out to a CSV file named by station coordinates.
+
+	Args:
+	-- loc_dict (dict) [opt]: dictionary mapping station ID/name to a (lat, long) coordinate tuple.
+	-- location_dataframes (dict) [opt]: dictionary mapping station ID/name to its processed GFS dataframe.
+	"""
 	for station in loc_dict:
 		location = loc_dict[station]
 		filename = f"{station}_{location[0]}_{location[1]}.csv"
 		location_dataframes[station].to_csv(filename)
 
 def execute(cmd):
+	"""
+	Runs a shell command as a subprocess and yields its stdout line by line as it's produced.
+
+	Args:
+	-- cmd (list of str) [req]: the command and arguments to execute, as passed to subprocess.Popen.
+
+	Yields:
+	Each line of stdout produced by the command, as it becomes available.
+
+	Raises:
+	subprocess.CalledProcessError: if the command exits with a non-zero return code.
+	"""
 	popen = sp.Popen(cmd, stdout=sp.PIPE, universal_newlines=True)
 	for stdout_line in iter(popen.stdout.readline, ""):
 		yield stdout_line
@@ -114,8 +133,17 @@ def execute(cmd):
 	if return_code:
 		raise sp.CalledProcessError(return_code, cmd)
 		
-# pulls just the desired lat/long pairs out of the datasets and isolat
 def isolate_loc_rows(ds, loc_dict):
+	"""
+	Selects and concatenates the grid cells corresponding to each requested lat/long pair out of a GFS xarray Dataset.
+
+	Args:
+	-- ds (xarray.Dataset) [req]: the GFS dataset to select from, indexed by 'latitude' and 'longitude'.
+	-- loc_dict (dict) [req]: dictionary mapping station ID/name to a (lat, long) coordinate tuple.
+
+	Returns:
+	An xarray.Dataset containing only the requested locations, concatenated along the 'latitude' dimension.
+	"""
 	# initialize empty list to store ds for each station in loc_dict
 	station_ds_list = []
 	for coords in loc_dict.values():
@@ -127,8 +155,16 @@ def isolate_loc_rows(ds, loc_dict):
 	concat_stations_ds = xr.concat(station_ds_list, dim="latitude")
 	return concat_stations_ds
 
-### In-place function that transforms the longitude indices from 0-360 t0 -180-180
 def remap_longs(ds):
+	"""
+	Remaps a dataset's longitude coordinate from the GFS's native 0-360 convention to the standard -180-180 convention.
+
+	Args:
+	-- ds (xarray.Dataset) [req]: the dataset whose 'longitude' coordinate should be remapped.
+
+	Returns:
+	A copy of the dataset with 'longitude' coordinate values remapped to the -180-180 range.
+	"""
 	map_function = lambda lon: (lon - 360) if (lon > 180) else lon
 	vector_fcn = np.vectorize(map_function)
 	longitudes = ds.coords["longitude"].values
@@ -147,9 +183,8 @@ def download_gfs(dates=dt.datetime.today().strftime("%Y%m%d"),
 	Args:
 	-- dates (list of strs) [opt]: list of dates to download gribs for. Default is just the current date
 	-- hours (list of strs) [opt]: list of forecast hours to download gribs for. Default is 7 day forecast, or 168 hours
-	-- log (logger) [required]: logger track info and download progress
 	-- grib_data_dir (str) [opt]: directory in which to store gfs grib files
-	
+
 	"""
 	print(f'TASK INITIATED: Download {int(hours[-1])}-hour GFS forecasts for the following dates: {dates}')
 	for d in dates:
@@ -223,7 +258,7 @@ def get_data(forecast_datetime,
 	-- end_datetime (str, date, or datetime) [req]: the end date and time for the forecast. GFS forecasts 16-days out for a given start date.
 	-- locations (dict) [req]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to download forecast data for.
 	-- data_dir (str) [opt]: directory to store donwloaded data. Defaults to OS's default temp directory.
-	-- dwnld_threads (int) [opt]: number of threads to use for downloads. Default is half of OS's available threads.
+	-- dnwld_threads (int) [opt]: number of threads to use for downloads. Default is half of OS's available threads.
 	-- load_threads (int) [opt]: number of threads to use for reading data. Default is 2 for GFS, since file reads are already pretty fast.
 	-- return_type (string) [opt]: string indicating which format to return data in. Default is "dict", which will return data in a nested dict format:
 									{locationID1:{

--- a/data/gfs_fc_thredds.py
+++ b/data/gfs_fc_thredds.py
@@ -111,11 +111,12 @@ def process_gfs_data(date,
 					 gfs_data_dir,
 					 num_threads):
 	"""
-	Will load NWM data and return a dictionary of timestamped streamflow data (pd.DataFrame) for each staion name in location_dict
+	Loads the downloaded GFS NetCDF files and returns a dictionary of timestamped meteorological data (pd.DataFrame) for each station name in location_dict.
 
 	Args:
 	-- date (datetime) [req]: datetime object representing the forecast date.
 	-- location_dict (dict) [req]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to load meterological data for.
+	-- variables_dict (dict) [req]: a dictionary mapping user-defined variable names to GFS dataset variable names.
 	-- gfs_data_dir (str) [req]: the directroy in which all of the GFS grib2 files are stored.
 	-- num_threads (int) [req]: number of threds to use for reading grib2 files
 
@@ -196,7 +197,7 @@ def get_data(forecast_datetime,
 	-- end_datetime (str, date, or datetime) [req]: the end date and time for the forecast. GFS forecasts 16-days out for a given start date.
 	-- locations (dict) [req]: a dictionary (stationID/name:IDValue/latlong tuple) of locations to download forecast data for.
 	-- data_dir (str) [opt]: directory to store donwloaded data. Defaults to OS's default temp directory.
-	-- dwnld_threads (int) [opt]: number of threads to use for downloads. Default is half of OS's available threads.
+	-- dnwld_threads (int) [opt]: number of threads to use for downloads. Default is half of OS's available threads.
 	-- load_threads (int) [opt]: number of threads to use for reading data. Default is 2 for GFS, since file reads are already pretty fast.
 	-- useTCDCInstant (bool) [opt]: wether to use instantaneous var for cloud cover or rolling average value.
 

--- a/data/lcd_ob.py
+++ b/data/lcd_ob.py
@@ -34,6 +34,15 @@ Var-specific processing functions:
 
 '''
 def splitsky ( instring ) :
+	"""
+	Extracts the sky cover code (e.g., 'CLR', 'SCT', 'OVC') from a raw LCD 'HourlySkyConditions' string, keeping the layer nearest the last ':' separator.
+
+	Args:
+	-- instring: the raw sky condition string to parse (e.g., 'FEW:02 007 SCT:04 015 OVC:08 021').
+
+	Returns:
+	The extracted sky cover code as a string, or a blank space (' ') if no valid code is found (including obscured-sky 'X' observations, which are discarded).
+	"""
 	thestring = str(instring)
 	tokens = thestring.split(':')   # looking for at least one cover code marker :
 	if len(tokens) > 1 :
@@ -46,11 +55,29 @@ def splitsky ( instring ) :
 	return token
 
 def sky2prop (theskycode) :
+  """
+  Converts an LCD sky cover code into a fractional sky cover proportion (0.0 = clear, 1.0 = fully overcast).
+
+  Args:
+  -- theskycode (str) [req]: sky cover code as returned by splitsky() (one of 'CLR', 'FEW', 'SCT', 'BKN', 'OVC', 'VV', or ' ').
+
+  Returns:
+  The corresponding sky cover fraction as a float.
+  """
   skypropmap = {'CLR': 0.000, 'FEW': 0.250, 'SCT': 0.5000, 'BKN': 0.875, 'OVC': 1.000, 'VV': 1.000, ' ': 1.000}
   theprop = skypropmap[str(theskycode)]
   return theprop
 
 def process_clouds(cloud_series):
+	"""
+	Converts a raw 'HourlySkyConditions' series into a series of fractional sky cover values, dropping entries that don't resolve to a valid sky code.
+
+	Args:
+	-- cloud_series (Pandas Series) [req]: raw 'HourlySkyConditions' values to process.
+
+	Returns:
+	A pandas Series of fractional sky cover values (see sky2prop()), with unresolved entries removed.
+	"""
 	cloud_series = cloud_series.apply(splitsky)
 	# Remove those that don't convert to skycode... junk entries
 	cloud_series = cloud_series[cloud_series != ' ']
@@ -58,6 +85,15 @@ def process_clouds(cloud_series):
 	return cloud_series
 
 def leavenotrace (precip) :
+	"""
+	Cleans a single raw LCD precipitation value: converts trace amounts ('T') to 0.00 and flags malformed multi-decimal values as NaN.
+
+	Args:
+	-- precip: the raw precipitation value to clean.
+
+	Returns:
+	The cleaned precipitation value as a string ('0.00' for trace, 'NaN' for malformed multi-decimal values, or the original value with any 's' suspect-value marker stripped).
+	"""
 	if str(precip) == 'T' :
 		return '0.00'
 	# Some suspect values (marked with s) contain junk data with 2 decimal points
@@ -69,6 +105,18 @@ def leavenotrace (precip) :
 		return str(precip).replace('s', '')
 
 def process_rain(precip_df, user_name):
+	"""
+	Cleans the 'HourlyPrecipitation' column of a raw LCD dataframe and adds it under a user-defined column name with units attached.
+
+	Args:
+	-- precip_df (Pandas DataFrame) [req]: raw LCD dataframe containing a 'HourlyPrecipitation' column.
+	-- user_name (str) [req]: column name to store the cleaned precipitation values under.
+
+	Returns:
+	The dataframe with a new float column named user_name (trace/malformed values cleaned via leavenotrace()), rows with NaN in a 'RAIN' column dropped, and a 'Units' column set to 'inches'.
+
+	Note: not currently called elsewhere in this module (get_data() cleans precipitation inline); the NaN filter is hardcoded to a 'RAIN' column rather than user_name.
+	"""
 	# First replace 'T's for trace precip with 0.0
 	#  leavenotrace also removes 's' notations on some precip values
 	#  Also, convert to float
@@ -113,8 +161,13 @@ Regardless, the general procedure for cleaning the raw data returned by the API 
 '''
 def clean_raw_df(raw_df):
 	'''
-	1. Remove duplicate values in the 'DATE' column
-	2. Set the index of the df to the 'DATE' column as UTC datetime timestamps, rename to 'time'
+	Deduplicates and re-indexes a raw LCD dataframe: removes duplicate 'DATE' entries (preferring FM-16 over FM-15 over FM-12 over SOD reports) and sets the index to the 'DATE' column as UTC datetime timestamps, renamed to 'time'.
+
+	Args:
+	-- raw_df (Pandas DataFrame) [req]: the raw LCD dataframe returned by lcdRequest(), containing 'DATE' and 'REPORT_TYPE' columns.
+
+	Returns:
+	A copy of the dataframe with duplicate timestamps removed and indexed by a UTC 'time' DatetimeIndex.
 	'''
 	# all of the duplicated Dates
 	all_dup_rows = raw_df.loc[raw_df['DATE'].duplicated(keep=False)]
@@ -211,6 +264,19 @@ def scrubSpecialChars(raw_series, inplace=False):
 # 	return pd.DataFrame(data={colToKeep: df[colToKeep].to_numpy(), 'Units':df['Units'].to_numpy()}, index=pd.DatetimeIndex(data=pd.to_datetime(df[index]), name='time')).tz_localize('UTC')
 
 def lcdRequest(startDate, endDate, var_list, station_id, units='standard'):
+	"""
+	Sends a request to the NOAA Local Climatological Data (LCD) API for the given station, variables, date range, and unit system, retrying until a valid JSON response is received.
+
+	Args:
+	-- startDate (datetime) [req]: start date for the data request (time is ignored; UTC midnight is used).
+	-- endDate (datetime) [req]: end date for the data request (exclusive; the request covers through 23:59 UTC of the day before).
+	-- var_list (list of str) [req]: LCD-specific variable names to request (e.g., 'HourlyPrecipitation').
+	-- station_id (str) [req]: LCD station ID to request data for.
+	-- units (str) [opt]: unit system for the request, 'standard' or 'metric'. Defaults to 'standard'.
+
+	Returns:
+	A pandas DataFrame of the raw JSON response from the LCD API, with one row per report and columns for each requested field plus metadata fields like 'DATE' and 'REPORT_TYPE'.
+	"""
 	# join all requested variables by a comma for the API call
 	varstring = (',').join(var_list)
 	# put this in loop since this fails frequently

--- a/data/nwm_fc.py
+++ b/data/nwm_fc.py
@@ -31,20 +31,20 @@ def prepForDownloads(
 	member: str,
 	download_dir: str
 ) -> tuple[dt.datetime, str, str]:
-	'''
+	"""
 	Prepares the directory structure, file name template, and reference date for downloading NWM forecast data, independent of the download method (GCS or NOMADs).
 
 	Args:
-	-- reference_date: The launch date and time of the forecast to download. Time should specify model cycle (e.g., '2015010112').
-	-- member: The member type of NWM forecast to get (e.g., medium_range_mem1, long_range_mem3, short_range, etc.).
-	-- download_dir: Directory to store downloaded data.
+		reference_date: The launch date and time of the forecast to download. Time should specify model cycle (e.g., '2015010112').
+		member: The member type of NWM forecast to get (e.g., medium_range_mem1, long_range_mem3, short_range, etc.).
+		download_dir: Directory to store downloaded data.
 
 	Returns:
-	tuple:
-		- reference_date: The parsed reference datetime object.
-		- netcdf_template: The file name template for the forecast files.
-		- nwm_date_dir: The precise directory where the forecast files will be stored. Mimics the NWM directory structure.
-	'''
+		A tuple containing:
+			- reference_date (datetime): The parsed reference datetime object.
+			- netcdf_template (str): The file name template for the forecast files.
+			- nwm_date_dir (str): The precise directory where the forecast files will be stored. Mimics the NWM directory structure.
+	"""
 	# parse the reference date
 	reference_date = utils.parse_to_datetime(reference_date)
 
@@ -79,22 +79,23 @@ def download_nwm(
 	download_dir: str = tf.gettempdir(),
 	num_threads: int = int(os.cpu_count() / 2)
 ) -> list[str]:
-	'''
-	Downloads NWM forecast data from either the Google Cloud Storage (GCS) or NOMADS server. Designed to download one forecast product at a time
+	"""
+	Downloads NWM forecast data from either the Google Cloud Storage (GCS) or NOMADS server. Designed to download one forecast product at a time.
+
 	NWM GCS Bucket: https://console.cloud.google.com/storage/browser/national-water-model
 	NWM NOMADS server: https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/prod/
 
 	Args:
-	-- reference_date: The launch date and time of the forecast to download. Time should specify model cycle (e.g., '2015010112').
-	-- member: The member type of NWM forecast to get (e.g., medium_range_mem1, long_range_mem3, short_range, etc.).
-	-- hours: The number of hours of forecast data to download. Default is 'all', which downloads all available files in the bucket. A list of integers indicating what hours to get is also acceptable (e.g., [12, 14, 16, ..., 20]).
-	-- gcs: Flag determining whether or not to use Google buckets for NWM download as opposed to NOMADS site. Default is True.
-	-- download_dir: Directory to store downloaded data. Defaults to OS's default temp directory.
-	-- num_threads: Number of threads to use for downloads. Default is half of OS's available threads.
+		reference_date: The launch date and time of the forecast to download. Time should specify model cycle (e.g., '2015010112').
+		member: The member type of NWM forecast to get (e.g., medium_range_mem1, long_range_mem3, short_range, etc.).
+		hours: The number of hours of forecast data to download. Default is 'all', which downloads all available files in the bucket. A list of integers indicating what hours to get is also acceptable (e.g., [12, 14, 16, ..., 20]). Defaults to 'all'.
+		gcs: Flag determining whether or not to use Google buckets for NWM download as opposed to NOMADS site. Defaults to True.
+		download_dir: Directory to store downloaded data. Defaults to OS's default temp directory.
+		num_threads: Number of threads to use for downloads. Defaults to half of OS's available threads.
 
 	Returns:
-	list: A list of file paths for the downloaded files.
-	'''
+		list: A list of file paths for the downloaded files.
+	"""
 	# prepare variables for NWM downloads, which includes 1) parsing the refernce date to a datetime object
 	# 2) breaking up the member string for file name and path construction, and enables us to then 3) define the directory for storing NWM data
 	reference_date, netcdf_template, nwm_date_dir = prepForDownloads(reference_date, member, download_dir)
@@ -174,23 +175,23 @@ def process_nwm(
 	end_date_exclusive: bool = True,
 	num_threads: int = int(os.cpu_count() / 2)
 ) -> dict | xr.Dataset:
-	'''
+	"""
 	Loads and processes NWM data from a single forecast product and returns the data in a format specified by the user. Data can be selected by start and end time, location, and variable.
 
 	Args:
-	-- start_ts: The start date (and time) for which to slice the forecast data.
-	-- end_ts: The end date (and time) for which to slice the forecast data.
-	-- locations: A dictionary or list of locations to pull out of the forecast files. When a dict is passed in the format {"user-name":"gauge_ID"}, the function will use those user-defined names when returning data. Otherwise, default location IDs found in the dataset are used.
-	-- variables: A dictionary or list of variables to pull out of the 'channel_rt' forecast files. When a dictionary is passed in the format {"user-name":"variable-name"}, the function will use those user-defined names when returning data. Otherwise, default variable names found in the dataset are used.
-	-- nwm_data_dir: The directory in which the NWM forecast files to process are located.
-	-- fname_template: The generic filename for the specific netCDF files being loaded, up to the timestamp component of the file name, '.f###'. For instance, for a medium_range_mem1 forecast launched at the t06z model cycle, the valid fname_template would be "nwm.t06z.medium_range.channel_rt_1".
-	-- format: The format in which to return the data. Default is 'dictionary', which returns a nested dictionary of pandas series. Other valid option is 'xarray', which returns an xarray dataset.
-	-- end_date_exclusive: Whether to exclude the ending timestamp from the time series. Defaults to True.
-	-- num_threads: Number of threads to use for reading netCDF files. Defaults to half of available CPUs to speed up processing.
+		start_ts: The start date (and time) for which to slice the forecast data.
+		end_ts: The end date (and time) for which to slice the forecast data.
+		locations: A dictionary or list of locations to pull out of the forecast files. When a dict is passed in the format {"user-name":"gauge_ID"}, the function will use those user-defined names when returning data. Otherwise, default location IDs found in the dataset are used.
+		variables: A dictionary or list of variables to pull out of the 'channel_rt' forecast files. When a dictionary is passed in the format {"user-name":"variable-name"}, the function will use those user-defined names when returning data. Otherwise, default variable names found in the dataset are used.
+		nwm_data_dir: The directory in which the NWM forecast files to process are located.
+		fname_template: The generic filename for the specific netCDF files being loaded, up to the timestamp component of the file name, '.f###'. For instance, for a medium_range_mem1 forecast launched at the t06z model cycle, the valid fname_template would be "nwm.t06z.medium_range.channel_rt_1".
+		format: The format in which to return the data. Defaults to 'dictionary', which returns a nested dictionary of pandas series. Other valid option is 'xarray', which returns an xarray dataset.
+		end_date_exclusive: Whether to exclude the ending timestamp from the time series. Defaults to True.
+		num_threads: Number of threads to use for reading netCDF files. Defaults to half of available CPUs to speed up processing.
 
 	Returns:
-	The processed NWM data in the requested format.
-	'''
+		The processed NWM data in the requested format (dict or xr.Dataset).
+	"""
 	# reconstructing the forecast member name based on the file name template
 	# using the file name tempate rather than the nwm_data_dir becasue unlike the directory names, the file name template must have the relevant information about the forecast product
 	fname_template_parts = fname_template.split('.')
@@ -326,29 +327,26 @@ def get_data(
 	dwnld_threads: int = int(os.cpu_count() / 2),
 	load_threads: int = int(os.cpu_count() / 2)
 ) -> dict | xr.Dataset:
-	'''
-	A function to download and process NWM hydrology forecast data to return nested dictionary of pandas series for each variable, for each location.
+	"""
+	Downloads and processes NWM hydrology forecast data to return nested dictionary of pandas series for each variable, for each location.
 
 	Args:
-	-- start_date: The start date for which to retrieve data.
-	-- end_date: The end date for which to retrieve data.
-	-- member: The member type of NWM forecast to get (medium_range_mem1, long_range_mem3, short_range, analysis_assim, etc).
-	-- locations: A dictionary or list of locations to pull out of the forecast files. When a dict is passed in the format {"user-name":"gauge_ID"},
-		then the function will use those user-defined names when returning data. Otherwise, default location IDs found in the dataset are used.
-	-- variables: A dictionary or list of variables to pull out of the 'channel_rt' forecast files. When a dictionary is passed in the format ("user-name":"variable-name"),
-		then the function will use those user-defined names when returning data. Otherwise, default variable names found in the dataset are used. 
-	-- reference_date: The forecast reference time, i.e., the date and time at which the forecast was initialized. Defaults to start_date if None.
-	-- data_dir: Directory to store downloaded data. Defaults to OS's default temp directory.
-	-- format: The format in which to return the data. Default is 'dictionary', which returns a nested dictionary of pandas series. Other valid option is 'xarray', which returns an xarray dataset.
-	-- gcs: Flag determining whether or not to use Google buckets for NWM download as opposed to NOMADs site. Default is True.
-	-- end_date_exclusive: Whether to exclude the end date from the time series. Defaults to True.
-	-- dwnld_threads: Number of threads to use for downloads. Default is half of OS's available threads.
-	-- load_threads: Number of threads to use for reading data. Default is half of OS's available threads.
+		start_date: The start date for which to retrieve data.
+		end_date: The end date for which to retrieve data.
+		member: The member type of NWM forecast to get (medium_range_mem1, long_range_mem3, short_range, analysis_assim, etc).
+		locations: A dictionary or list of locations to pull out of the forecast files. When a dict is passed in the format {"user-name":"gauge_ID"}, the function will use those user-defined names when returning data. Otherwise, default location IDs found in the dataset are used.
+		variables: A dictionary or list of variables to pull out of the 'channel_rt' forecast files. When a dictionary is passed in the format {"user-name":"variable-name"}, the function will use those user-defined names when returning data. Otherwise, default variable names found in the dataset are used.
+		reference_date: The forecast reference time, i.e., the date and time at which the forecast was initialized. Defaults to start_date if None.
+		data_dir: Directory to store downloaded data. Defaults to OS's default temp directory.
+		format: The format in which to return the data. Defaults to 'dictionary', which returns a nested dictionary of pandas series. Other valid option is 'xarray', which returns an xarray dataset.
+		gcs: Flag determining whether or not to use Google buckets for NWM download as opposed to NOMADs site. Defaults to True.
+		end_date_exclusive: Whether to exclude the end date from the time series. Defaults to True.
+		dwnld_threads: Number of threads to use for downloads. Defaults to half of OS's available threads.
+		load_threads: Number of threads to use for reading data. Defaults to half of OS's available threads.
 
 	Returns:
-	NWM timeseries for the given locations in a nested dict format where 1st-level keys are user-provided location names and 2nd-level keys
-	are variable names and values are the respective data in a Pandas Series object, or an xarray Dataset if format='xarray'.
-	'''
+		NWM timeseries for the given locations. Nested dict format where 1st-level keys are user-provided location names and 2nd-level keys are variable names with values as Pandas Series objects, or an xarray Dataset if format='xarray'.
+	"""
 	# Validate and process date & times
 	# for analysis assimilation data, the reference date is the date and time of the corresponding short-range forecast launch
 	# so start and end dates for analysis assimilation data must come BEFORE the reference date, unlike forecast products

--- a/data/nwm_forcings_fc.py
+++ b/data/nwm_forcings_fc.py
@@ -473,8 +473,7 @@ def get_data(
 	Args:
 	-- start_date: The start date for which to retrieve data.
 	-- end_date: The end date for which to retrieve data.
-	-- member: The NWM forecast member for which you to get forcings for (Currently accepts 'medium_range', 'short_range', 'analysis_assim', and 'analysis_assim_extend').	-- locations: A dictionary containing either bounding box information or a list of points to extract from the gridded forcings dataset. Default value of None does not spatially subset the data. See validate_locations() for more details.
-		Note that the bounding box must be in latitude, longitude (WGS 1984), but the dataset is NOT reprojected and will maintain its orginal CRS.
+	-- member: The NWM forecast member for which you to get forcings for (Currently accepts 'medium_range', 'short_range', 'analysis_assim', and 'analysis_assim_extend').
 	-- locations: A dictionary containing either bounding box information or a dict of points to extract from the gridded forcings dataset. Default value of None does not spatially subset the data. See validate_locations() for more details.
 		Note that the bounding box must be in latitude, longitude (WGS 1984), but the dataset is NOT reprojected and will maintain its orginal CRS.
 	-- variables: A dictionary or list of variables to pull out of the forcing files. When a dictionary is passed in the format {"user-name":"variable-name"}, the function will use those user-defined names when returning data. Otherwise, the variable names found in the dataset are used. Default value 'all' keeps all variables

--- a/data/sentinel3_ob.py
+++ b/data/sentinel3_ob.py
@@ -21,7 +21,15 @@ import matplotlib.pyplot as plt
 import matplotlib.colors as mc
 
 class CIFilesDownloadProcess:
-    def __init__ (self, app_key, start_date, end_date, output_dir, cropbox, 
+    """
+    Orchestrates the Cyanobacterial Index (CI) tile pipeline: fetching tile URLs from NASA's
+    Ocean Color CyAN portal, downloading the GeoTIFF tiles, reprojecting them to WGS84, cropping
+    them to an area of interest, and (optionally) converting Digital Number (DN) values to CI values.
+
+    Instances hold the configuration (app key, date range, output/temp directories, crop box, area ID)
+    and expose one method per pipeline stage; get_data() drives them in sequence.
+    """
+    def __init__ (self, app_key, start_date, end_date, output_dir, cropbox,
                  areaid, convert_to_ci=False, remove_temp=True):
         """
         
@@ -197,10 +205,13 @@ class CIFilesDownloadProcess:
     @staticmethod
     def dn_to_ci(input_file, output_file):
         """
-        Transforms DN values to CI values.
+        Transforms a GeoTIFF's Digital Number (DN) values to Cyanobacterial Index (CI) values and writes the result.
 
-        For DN to CI Formula See - https://oceancolor.gsfc.nasa.gov/about/projects/cyan/
-        
+        For the DN to CI formula, see: https://oceancolor.gsfc.nasa.gov/about/projects/cyan/
+
+        Args:
+            input_file (str or Path): path to the source DN GeoTIFF.
+            output_file (str or Path): path to write the converted CI GeoTIFF to.
         """
         with rasterio.open(input_file) as src:
             dn_img = src.read(1)
@@ -241,16 +252,32 @@ class CIFilesDownloadProcess:
             
     def time_index_from_filenames(self, filenames, string_slice=slice(0, 10)):
         '''
-        Helper function to generate a Pandas datetimeindex object
-            from dates contained in a file path string
+        Generates a Pandas DatetimeIndex from the dates encoded in a list of file path strings.
+
+        Args:
+            filenames (list of str): file paths whose basenames contain a date in '%Y%j' (year + day-of-year) format.
+            string_slice (slice, optional): the slice of each basename that holds the date string. Defaults to slice(0, 10).
+
+        Returns:
+            A pandas DatetimeIndex parsed from the extracted date strings.
         '''
-    
+
         date_strings = [os.path.basename(i)[string_slice] for i in filenames]
-    
+
         return pd.to_datetime(date_strings,format='%Y%j')
 
 
     def tif_to_ds(self):
+        '''
+        Loads the cropped DN GeoTIFFs into a single time-stacked xarray Dataset.
+
+        Reads every GeoTIFF in the crop directory, stacks them along a 'time' dimension (labeled from
+        the dates in each filename), renames the raster band to 'DN', sets the CRS to EPSG:4326, and
+        sorts by time.
+
+        Returns:
+            An xarray Dataset with a 'DN' variable stacked along a 'time' dimension, in the EPSG:4326 CRS.
+        '''
         # Get file paths and obtain list of dates from file
         print("Load Downloaded TIF Files into Dataset")
         mosaic_files = sorted(list(self.crop_dir_path.glob('*.tif')))
@@ -282,36 +309,24 @@ def get_data(start_date,
 			variables={'streamflow':'Débit (m³/s)'},
 			service='iv'):
     """
-    A function to download and process Sentinel 3 observational cyano index image data
+    Downloads and processes Sentinel-3 observational Cyanobacterial Index (CI) image data, returning a time-stacked xarray Dataset of Digital Number (DN) rasters for the requested area and date range.
 
     Args:
-    -- start_date (str, date, or datetime) [req]: the start date for which to grab Canadian Instantaneous data
-    -- end_date (str, date, or datetime) [req]: the end date for which to grab Canadian Instantaneous data
-	-- service (str) [opt]: what frequency of data to get. Default is 'iv', or instantaneous data (15-min frequency). Other option is 'dv', which returns daily data. For more info, see https://www.cehq.gouv.qc.ca/hydrometrie/historique_donnees/fiche_station.asp?NoStation=030425
-    -- app_key (str): string containing the app key for authentication.
-    -- output_dir (str)              : Directory where output files will be saved.
-    -- cropbox (lat,lon,lat,lon)       : corners of the area to crop the geotiff with
-    -- areaid(str)                     : string designating the tileid/areaid for the tiles to download, i.e. "8_2" for Champlain Valley
-    -- convert_to_ci (bool, optional): Flag indicating whether to convert Digital Number (DN) values to CI values. Defaults to False.
-    -- remove_temp (bool, optional)  : Flag indicating whether to remove temporary files after processing. Defaults to True.
+    -- start_date (str, date, or datetime) [req]: the start date for which to grab CI tiles.
+    -- end_date (str, date, or datetime) [req]: the end date for which to grab CI tiles.
+    -- appkey (str) [req]: the NASA Ocean Color app key for authentication.
+    -- cropbox (tuple) [req]: (lat, lon, lat, lon) corners of the area to crop each GeoTIFF to.
+    -- output_dir (str) [req]: directory where output files (and intermediate temp files) will be saved.
+    -- remove_temp (bool) [opt]: whether to remove temporary files after processing. Defaults to True.
+    -- convert_to_ci (bool) [opt]: whether to convert Digital Number (DN) values to CI values. Defaults to False (conversion currently produces problematic results and is not recommended).
+    -- areaid (str) [opt]: the tile/area ID to download, i.e. "8_2" for the Champlain Valley. Defaults to "8_2".
 
-        Attributes:
-            app_key (str): The app key for authentication.
-            start_date (str): Start date for downloading CI files.
-            end_date (str): End date for downloading CI files.
-            output_dir (Path): Path object for the output directory.
-            temp_dir (Path): Path object for the temporary directory.
-            urls_file (Path): Path object for the file storing the list of URLs to download.
-            geotiff_path (Path): Path object for the directory storing downloaded GeoTIFF files.
-            projected_path (Path): Path object for the directory storing reprojected GeoTIFF files.
-            crop_dir_path (Path): Path object for the directory storing cropped DN GeoTIFF files.
-            ci_output_path (Path, optional): Path object for the directory storing converted CI GeoTIFF files if `convert_to_ci` is True.
-            convert_to_ci (bool): Indicates whether to convert DN to CI values.
-            remove_temp (bool): Indicates whether to remove temporary files after processing.	
- 
-	Returns:
-	Sentinel 3 satellite  observed data for the specified Tile ID in an xarray dataset where time slices represent each downloaded Tile for variable "DN"
-	"""
+    Note:
+    The `locations`, `variables`, and `service` parameters are accepted but not currently used; the area downloaded is controlled entirely by `areaid` and `cropbox`.
+
+    Returns:
+    An xarray Dataset for the specified tile/area, where each time slice represents a downloaded tile, holding the variable "DN".
+    """
     start_date = parse_to_datetime(start_date)
     end_date = parse_to_datetime(end_date)
     yearlist = list(range(start_date.year, end_date.year+1)) # the list of all years data is requested for
@@ -350,10 +365,17 @@ def get_data(start_date,
     return sentinel3_data
 
 def plot (da, cmap=None, base=True, title=None, **kwargs) :
-        """ Plot a Sentinel3 DN for a time slice (2 dimensional array)
-                If no colormap (cmap) passed, build a custom color map for DN encoding
-                If base=True, display a basemap using CRS from passed dataset
-                If title=None, let plot function build default title from data context
+        """
+        Plots a Sentinel-3 DN time slice (a 2-dimensional array).
+
+        Args:
+            da (xarray.DataArray) [req]: a single time slice (2D) of DN data to plot.
+            cmap (matplotlib colormap) [opt]: colormap to use. If None, a custom DN-encoding colormap is built (ground value 254 white, no-data/cloud value 255 black). Defaults to None.
+            base (bool) [opt]: whether to display a basemap using the CRS from the passed dataset. Defaults to True.
+            title (str) [opt]: plot title. If None, no title is set. Defaults to None.
+
+        Returns:
+            The matplotlib Axes object for the plot.
         """
             
         if (cmap == None) :

--- a/data/usgs_ob.py
+++ b/data/usgs_ob.py
@@ -17,14 +17,13 @@ def USGSgetvars_function(id, variables, start, end, service='iv'):
 
 	Args:
 	-- id (str) [req]: station ID to get data for
-	-- variables (dictionary) : {'column name' : 'usgs var code'}
-	-- paramter (str) [req]: parameter code of data to get
+	-- variables (dict) [req]: a dictionary mapping user-defined variable names to USGS parameter codes, i.e. {'column name' : 'usgs var code'}.
 	-- start (datetime) [req]: start datetime
 	-- end (datetime) [req]: end datetime
 	-- service (str) [opt]: what USGS service to get data from. Default is instanteous values service. For more options, see https://waterservices.usgs.gov/docs/
 
 	Returns:
-	A dataframe of USGS streamflow data indexed by timestamp
+	A dictionary mapping each variable name to a Pandas Series of that variable's data, indexed by timestamp and named "{var} ({unit})".
 	"""
 	# daily values service does not accept timezones, but instantaneous values service does
 	if service == 'dv':

--- a/data/utils.py
+++ b/data/utils.py
@@ -491,7 +491,7 @@ def plot_ts(series_list, scale='auto', **kwargs):
 	Args:
 	-- series_list (list) [req]: a list of Pandas.Series to plot
 	-- scale (str) [opt]: determines the x-axis tick mark scale. Options are:
-	 	- 'years'
+		- 'years'
 		- 'months'
 		- 'weeks'
 		- 'days'
@@ -501,12 +501,14 @@ def plot_ts(series_list, scale='auto', **kwargs):
 		- interval (int): interval for x-axis tick marks, whether the scale be days, hours, etc
 		- labels (list): list of labels to use for each series, respectively, in plt.plot()
 		- colors (list): list of colors to use for each series, respectively, in plt.plot()
+		- figsize (tuple): dimensions of the subplots, in inches (width, height). Default is (10, 16).
 		- title (str): a custom title for the plot
 	
 	Returns:
 	the figure object created. 
 	""" 
-	fig, ax = plt.subplots(figsize=(10, 6))
+	fig_size = kwargs.pop('figsize', (10, 6))
+	fig, ax = plt.subplots(figsize=fig_size)
 	
 	# Extract label from kwargs if it exists
 	interval = kwargs.pop('interval', 1)
@@ -575,7 +577,7 @@ def plot_nested_dict(data, **kwargs):
 			- interval (int): interval for x-axis tick marks, whether the scale be days, hours, etc (forwarded to plot_ts() in single-variable cases only)
 			- labels (list): list of labels to use for each series, respectively, in plt.plot()
 			- colors (list): list of colors to use for each series, respectively, in plt.plot()
-			- figsize (tuple): dimensions of the subplots, in inches (width, height). Default is (10, 8).
+			- figsize (tuple): dimensions of the subplots, in inches (width, height). Default is (10, 16).
 			- nrows (int): number of rows to make in the subplot figure. Default value is the number of variables.
 			- ncols (int): number of columns to make in the subplot figure. Default value is 1.
 	"""
@@ -587,10 +589,13 @@ def plot_nested_dict(data, **kwargs):
 
 	# if there's more than 1 variable to plot, we need to make subplots
 	if n > 1:
-		figsize = kwargs.pop('figdims', (10, 8))
+		figsize = kwargs.pop('figsize', (10, 16))
 		# determine number of rows and columsn for the figure object
 		nrows = kwargs.pop('nrows', n)
 		ncols = kwargs.pop('ncols', 1)
+		# the number of subplots to make (ncols * nrows) must be equal to the number of variables
+		if ncols * nrows != n:
+			raise ValueError(f"Product of nrows and ncols if passed must equal the number of variables to be plotted")
 		fig, axes = plt.subplots(nrows, ncols, figsize=figsize)  # Create subplots
 		# check to see if colors (list) was passed. If not, set to None
 		colors = kwargs.pop('colors', None)
@@ -598,15 +603,42 @@ def plot_nested_dict(data, **kwargs):
 			# define a color map
 			cmap = plt.get_cmap("tab10") # 'Set1', 'Set2'
 			colors = [cmap(i) for i in range(len(locations))]
-		for i, var in enumerate(variables):
-			for j, loc in enumerate(locations):
-				series = data[loc][var]
-				axes[i].plot(series.index, series.values, label=loc, color=colors[j])
-				axes[i].set_title(var)
-				axes[i].set_xlabel('Datetime')
-				axes[i].set_ylabel(series.name)
-				axes[i].legend()
-				axes[i].grid()
+		var_idx = 0
+		for i in range(nrows):
+			if ncols == 1:
+				for c, loc in enumerate(locations):
+					var = variables[var_idx]
+					# print(f"plotting {var} for {loc}")
+					# print(f"subplot location: {i}")
+					series = data[loc][var]
+					axes[i].plot(series.index, series.values, label=loc, color=colors[c])
+					axes[i].set_title(var)
+					axes[i].set_xlabel('Datetime', fontsize=8)
+					axes[i].tick_params(axis='both', labelsize=6)
+					axes[i].set_ylabel(series.name, fontsize=8)
+					axes[i].legend()
+					axes[i].grid()
+				var_idx = var_idx+1
+			else:
+				for j in range(ncols):
+					for c, loc in enumerate(locations):
+						var = variables[var_idx]
+						# print(f"plotting {var} for {loc}")
+						# print(f"subplot location: {i,j}")
+						series = data[loc][var]
+						try:
+							# In the `plot_nested_dict` function, the `axes` variable is being used to store the subplot axes when creating multiple subplots within a single figure. It is a multidimensional array of subplot axes objects that are created using `plt.subplots(nrows, ncols, figsize=figsize)`.
+							axes[i,j].plot(series.index, series.values, label=loc, color=colors[c])
+							axes[i,j].set_title(var)
+							axes[i,j].set_xlabel('Datetime', fontsize=8)
+							axes[i,j].tick_params(axis='both', labelsize=6)
+							axes[i,j].set_ylabel(series.name, fontsize=8)
+							axes[i,j].legend()
+							axes[i,j].grid()
+						except Exception as e:
+							# raise(e)
+							return axes
+					var_idx = var_idx+1
 
 		plt.tight_layout()  # Adjust layout to prevent overlap
 		return fig

--- a/data/utils.py
+++ b/data/utils.py
@@ -570,8 +570,8 @@ def plot_nested_dict(data, **kwargs):
 	"""
 	Makes a figure with n subplots, where n is the number of vaiables in each location dict. Must have the same variables for each location
 
-	Parameters:
-		-- data (dict): A nested dictionary where the outer keys are categories 
+	Args:
+		-- data (dict): A nested dictionary where the outer keys are categories
 						and the inner keys are variables with their corresponding values.
 		-- kwargs [opt]: various kwargs to pass to matpllotlib plotting functions. 
 			- interval (int): interval for x-axis tick marks, whether the scale be days, hours, etc (forwarded to plot_ts() in single-variable cases only)
@@ -780,6 +780,16 @@ def strip_non_numeric_chars(raw_series):
 	return corrected_series.astype(float)
 
 def validate_ref_date(start_date: dt.datetime, reference_date: dt.datetime | None=None):
+	'''
+	Resolves the forecast reference date: returns start_date if no reference_date is given, otherwise parses and returns the provided reference_date.
+
+	Args:
+	-- start_date (dt.datetime) [req]: the forecast start date, used as the reference date when reference_date is None.
+	-- reference_date (dt.datetime or None) [opt]: the forecast reference time. Defaults to None, in which case start_date is used.
+
+	Returns:
+	A datetime object representing the resolved forecast reference date.
+	'''
 	# if no reference time is passed, set it to start date
 	if reference_date is None:
 		reference_date = start_date

--- a/docs/aorc_ob.md
+++ b/docs/aorc_ob.md
@@ -1,0 +1,22 @@
+---
+icon: lucide/cloud-rain
+---
+
+# NOAA AORC Meteorological Reanalysis
+
+Downloads gridded, hourly meteorological reanalysis data from NOAA's Analysis of Record for Calibration (AORC) v1.1 dataset, reading directly from the [public Zarr store on AWS S3](https://registry.opendata.aws/noaa-nws-aorc/) (anonymous access, no download step required). For each requested location, the nearest available grid cell is selected.
+
+## `get_data()`
+
+Downloads and processes AORC reanalysis data, returning a nested dictionary of Pandas Series for each variable, for each location.
+
+**Parameters:**
+
+- `start_date` — the start date for which to grab data.
+- `end_date` — the end date for which to grab data.
+- `locations` — a dictionary mapping location name to a `(lat, lon)` coordinate tuple.
+- `variables` — a dictionary mapping user-defined variable names to AORC dataset variable names, e.g. `APCP_surface` (total precipitation), `TMP_2maboveground` (air temperature), `SPFH_2maboveground` (specific humidity), `DLWRF_surface`/`DSWRF_surface` (long/short-wave radiation), `PRES_surface` (pressure), `UGRD_10maboveground`/`VGRD_10maboveground` (wind components).
+
+**Returns:**
+
+- A nested dict where 1st-level keys are user-provided location names and 2nd-level keys are variable names, with values as Pandas Series.

--- a/docs/caflow_ob.md
+++ b/docs/caflow_ob.md
@@ -1,0 +1,48 @@
+---
+icon: lucide/droplet
+---
+
+# Canadian Hydrometric Streamflow (CEHQ)
+
+Downloads observed streamflow data for Quebec tributary gauges (e.g. Pike and Rock, tributaries of Missisquoi Bay) from the [CEHQ](https://www.cehq.gouv.qc.ca/) (Centre d'expertise hydrique du Québec) historical data archive. Supports both instantaneous (15-minute) and daily-averaged data.
+
+## `get_data()`
+
+Downloads and processes Canadian observational hydrology data, returning a nested dictionary of Pandas Series for each variable, for each location.
+
+**Parameters:**
+
+- `start_date` — the start date for which to grab data.
+- `end_date` — the end date for which to grab data.
+- `locations` — a dictionary of station name to CEHQ station ID. Defaults to `{'Pike':'030424', 'Rock':'030425'}`.
+- `variables` — a dictionary of variables to download; the only currently supported value is `'Débit (m³/s)'` (streamflow). Defaults to `{'streamflow':'Débit (m³/s)'}`.
+- `service` — which frequency of data to get: `'iv'` for instantaneous (15-minute, default) or `'dv'` for daily. See the [station page](https://www.cehq.gouv.qc.ca/hydrometrie/historique_donnees/fiche_station.asp?NoStation=030425) for details.
+
+**Returns:**
+
+- A nested dict where 1st-level keys are user-provided station names and 2nd-level keys are variable names, with values as Pandas Series in m³/s.
+
+## `get_instantaneous()`
+
+Downloads and concatenates instantaneous (15-minute frequency) streamflow records for a single station across one or more years.
+
+**Parameters:**
+
+- `id` — CEHQ station ID.
+- `yearlist` — years to download instantaneous data for. Years with a failed request are skipped.
+
+**Returns:**
+
+- A Pandas DataFrame of concatenated instantaneous streamflow records, indexed by date/time.
+
+## `get_daily()`
+
+Downloads daily streamflow records for a single station.
+
+**Parameters:**
+
+- `id` — CEHQ station ID.
+
+**Returns:**
+
+- A Pandas DataFrame of daily streamflow records, indexed by date.

--- a/docs/cfs_fc.md
+++ b/docs/cfs_fc.md
@@ -1,0 +1,47 @@
+---
+icon: lucide/cloud-sun
+---
+
+# NOAA CFS (Climate Forecast System) 9-Month Forecast
+
+Downloads and processes NOAA's [CFSv2 operational 9-month forecast](https://www.ncei.noaa.gov/products/weather-climate-models/climate-forecast-system) (available from 2011-04-01 to present) from the [NCEI THREDDS server](https://www.ncei.noaa.gov/thredds/catalog/model-cfs_v2_for_ts/catalog.html). Two retrieval strategies are supported: downloading full forecast files (`fileServer`), or requesting a server-side spatial/temporal slice via the NetCDF Subset Service (`ncss`) — useful for reducing bandwidth, though not always suitable for shared network drives.
+
+## `get_data()`
+
+Downloads and processes CFS forecast data, returning a nested dictionary of Pandas Series for each variable, for each location.
+
+**Parameters:**
+
+- `start_date` / `end_date` — the date range to retrieve data for.
+- `locations` — a dictionary mapping location name to a `(lat, lon)` tuple.
+- `variables` — a dictionary mapping user-defined variable names to CFS long names (keys of `CFS_VAR_NAMES`, e.g. `'Temperature_height_above_ground'`, `'Precipitation_rate_surface'`).
+- `reference_date` — the forecast reference time (initialization time). Defaults to `start_date` if `None`. Must align to a CFS forecast cycle (0, 6, 12, or 18 UTC).
+- `ncss` — whether to use the NetCDF Subset Service instead of downloading full files. Defaults to `False`.
+- `end_date_exclusive` — whether to exclude `end_date` from the returned series. Defaults to `True`.
+- `data_dir` — directory to store downloaded data. Defaults to the OS temp directory.
+- `num_threads` — number of threads for downloading. Defaults to half the available CPU cores.
+
+**Returns:**
+
+- A nested dict where 1st-level keys are user-provided location names and 2nd-level keys are variable names, with values as Pandas Series with units attached.
+
+## `download_full_cfs()` / `download_ncss()`
+
+Download the full forecast files, or a server-subsetted slice, respectively, for a given reference date and variable set.
+
+**Parameters:** `reference_date`, `variables`, `data_dir`, `num_threads` (both); `download_ncss()` additionally takes `locations`, `start_date`, `end_date` to build the spatial/temporal subset request.
+
+**Returns:** a list of local file paths for the downloaded files.
+
+## `process_full_cfs()` / `process_ncss()`
+
+Extract per-location, per-variable time series from a downloaded full-file dataset or NCSS dataset, respectively, mapping requested `(lat, lon)` locations to the nearest available grid coordinates.
+
+**Parameters:** `ds` (the opened xarray Dataset), `variables`, `locations`.
+
+**Returns:** a nested dict of Pandas Series (see `get_data()`), with units attached.
+
+??? info "Internal helpers"
+    - `construct_download_paths()` — builds THREDDS download URLs and local file paths for a given reference date and variable set.
+    - `execute_downloads()` — runs the actual multi-threaded download given a list of URLs and destination paths.
+    - `remap_to_cfs_coords()` — converts `(lat, lon)` tuples from -180/180 to the 0/360 longitude convention CFS uses.

--- a/docs/femc_ob.md
+++ b/docs/femc_ob.md
@@ -1,0 +1,35 @@
+---
+icon: lucide/cloud-sun
+---
+
+# UVM FEMC Meteorological Observations (Colchester Reef)
+
+Downloads observed meteorological data from the UVM [Forest Ecosystem Monitoring Cooperative](https://www.uvm.edu/femc/) (FEMC) Colchester Reef station on Lake Champlain. The underlying data is split across three sources with different formats and update cadences — a large historical "v1" archive, a "v2" archive starting 2024-07-26, and a rolling "latest" feed covering roughly the last 21 days — which this module stitches together transparently.
+
+## `get_data()`
+
+Downloads and processes FEMC observational data, returning a nested dictionary of Pandas Series for each variable, for each location.
+
+**Parameters:**
+
+- `start_date` — the start date for which to grab data.
+- `end_date` — the end date for which to grab data.
+- `locations` — a dictionary of location name to station ID. Defaults to `{'CR':'ColReefQAQC'}` (Colchester Reef is currently the only supported station).
+- `variables` — a dictionary of variables to get; keys are user-defined names, values must be one of the FEMC abbreviations `T2` (air temp), `SWDOWN` (shortwave radiation), `RH2` (relative humidity), `WSPEED` (wind speed), `WDIR` (wind direction).
+
+**Returns:**
+
+- A nested dict where 1st-level keys are user-provided location names and 2nd-level keys are variable names, with values as Pandas Series with units attached.
+
+## `load_femc_data()`
+
+Loads and merges the raw v1, v2, and latest datasets for the requested date range, choosing only the sources actually needed to cover it.
+
+**Parameters:**
+
+- `start_date` — the start date for which to load data.
+- `end_date` — the end date for which to load data (cannot be in the future).
+
+**Returns:**
+
+- A Pandas DataFrame of raw meteorological data spanning the requested range, indexed by timestamp and sorted chronologically. The v1 dataset is loaded lazily via Dask due to its size; v2 and the latest feed are loaded with pandas.

--- a/docs/gfs_fc.md
+++ b/docs/gfs_fc.md
@@ -1,0 +1,49 @@
+---
+icon: lucide/cloud
+---
+
+# NOAA GFS Forecast (NOMADS)
+
+Downloads and processes NOAA's GFS 0.25° forecast for a fixed Lake Champlain bounding box, using the [NOMADS GRIB filter service](https://nomads.ncep.noaa.gov/cgi-bin/filter_gfs_0p25.pl).
+
+!!! warning "Deprecated"
+    `get_data()` raises a `DeprecationWarning`. [`gfs_fc_thredds`](gfs_fc_thredds.md) is the recommended module for acquiring GFS forecast data going forward.
+
+## `get_data()`
+
+Downloads and processes GFS forecast data, returning a nested dictionary of Pandas Series for each variable, for each location.
+
+**Parameters:**
+
+- `forecast_datetime` — the forecast launch date and cycle (00/06/12/18 UTC).
+- `end_datetime` — the end date/time of the forecast window (GFS forecasts out to 16 days).
+- `locations` — a dictionary mapping station name to a `(lat, lon)` tuple.
+- `data_dir` — directory to store downloaded data. Defaults to the OS temp directory.
+- `dnwld_threads` / `load_threads` — thread counts for downloading and reading grib files, respectively.
+- `return_type` — `'dict'` (default) for a nested Series dict, or `'dataframe'` (not yet implemented).
+
+**Returns:**
+
+- A nested dict where 1st-level keys are user-provided location names and 2nd-level keys are variable names, with values as Pandas Series.
+
+## `download_gfs_threaded()`
+
+Downloads the GRIB2 files for a forecast date across the requested hours, throttled to stay within NOMADS's requested rate limit (50 requests/minute, in chunks with a 60-second pause between them).
+
+**Parameters:** `date`, `hours`, `gfs_data_dir`, `num_threads`.
+
+## `process_gfs_data()`
+
+Loads the downloaded GRIB2 files, isolates the requested locations, renames variables to the workflow's standard convention (`T2`, `TCDC`, `SWDOWN`, `U10`, `V10`, `RH2`, `RAIN`, `CPOFP`), and assembles a per-station DataFrame indexed by time.
+
+**Parameters:** `location_dict`, `gfs_data_dir`, `num_threads`.
+
+**Returns:** a dict of `{station_ID: pd.DataFrame}`.
+
+??? info "Internal helpers"
+    - `download_gfs()` — an older, non-throttled, non-threaded download function; superseded by `download_gfs_threaded()` and not currently called by `get_data()`.
+    - `calibrate_columns()` / `append_timestamp()` — rename/reorder variable columns to the standard convention and append each timestep's data into the running per-station DataFrame.
+    - `dict_to_csv()` — writes per-station DataFrames out to CSV (not currently called elsewhere).
+    - `execute()` — generic subprocess runner that yields stdout line by line.
+    - `isolate_loc_rows()` — selects the grid cells nearest each requested `(lat, lon)` out of a GFS dataset.
+    - `remap_longs()` — remaps GFS's native 0–360 longitude convention to -180–180.

--- a/docs/gfs_fc_thredds.md
+++ b/docs/gfs_fc_thredds.md
@@ -1,0 +1,41 @@
+---
+icon: lucide/cloud
+---
+
+# NOAA GFS Forecast (THREDDS)
+
+Downloads and processes NOAA's GFS 0.25° forecast for a fixed Lake Champlain bounding box, using server-side NetCDF Subset Service (NCSS) requests against [UCAR RDA's THREDDS server](https://thredds.rda.ucar.edu/thredds/catalog/files/g/ds084.1/catalog.html). This is the recommended module for GFS acquisition — it supersedes [`gfs_fc`](gfs_fc.md), which is deprecated.
+
+## `get_data()`
+
+Downloads and processes GFS forecast data, returning a nested dictionary of Pandas Series for each variable, for each location.
+
+**Parameters:**
+
+- `forecast_datetime` — the forecast launch date and cycle (00/06/12/18 UTC).
+- `end_datetime` — the end date/time of the forecast window.
+- `locations` — a dictionary mapping station name to a `(lat, lon)` tuple.
+- `data_dir` — directory to store downloaded data. Defaults to the OS temp directory.
+- `dnwld_threads` / `load_threads` — thread counts for downloading and reading data, respectively.
+- `useTCDCInstant` — whether to use the instantaneous total-cloud-cover variable instead of the default 3/6-hour rolling average. Defaults to `False`.
+
+**Returns:**
+
+- A nested dict where 1st-level keys are user-provided location names and 2nd-level keys are variable names (`T2`, `TCDC`, `U10`, `V10`, `RH2`, `RAIN`, `CPOFP`, `SWDOWN`), with values as Pandas Series.
+
+## `download_gfs_threaded()`
+
+Builds NCSS request URLs for each forecast hour (handling the special-cased 3/6-hour-average variables like cloud cover and shortwave radiation) and downloads them, throttled to stay within rate limits.
+
+**Parameters:** `date`, `hours`, `gfs_data_dir`, `variables`, `num_threads`.
+
+## `process_gfs_data()`
+
+Loads the downloaded NetCDF files (skipping any truncated/bad files), isolates the requested locations (reusing [`isolate_loc_rows()`/`remap_longs()`](gfs_fc.md) from `gfs_fc`), renames variables to the standard convention, and assembles a per-station DataFrame indexed by time.
+
+**Parameters:** `date`, `location_dict`, `variables_dict`, `gfs_data_dir`, `num_threads`.
+
+**Returns:** a dict of `{station_ID: pd.DataFrame}`.
+
+??? info "Internal helpers"
+    - `append_timestamp()` — appends a single forecast hour's data into the running per-station DataFrame.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,173 @@
+---
+icon: lucide/rocket
+---
+
+# Get started
+
+For full documentation visit [zensical.org](https://zensical.org/docs/).
+
+## Commands
+
+* [`zensical new`][new] - Create a new project
+* [`zensical serve`][serve] - Start local web server
+* [`zensical build`][build] - Build your site
+
+  [new]: https://zensical.org/docs/usage/new/
+  [serve]: https://zensical.org/docs/usage/preview/
+  [build]: https://zensical.org/docs/usage/build/
+
+## Examples
+
+### Admonitions
+
+> Go to [documentation](https://zensical.org/docs/authoring/admonitions/)
+
+!!! note
+
+    This is a **note** admonition. Use it to provide helpful information.
+
+!!! warning
+
+    This is a **warning** admonition. Be careful!
+
+### Details
+
+> Go to [documentation](https://zensical.org/docs/authoring/admonitions/#collapsible-blocks)
+
+??? info "Click to expand for more info"
+
+    This content is hidden until you click to expand it.
+    Great for FAQs or long explanations.
+
+## Code Blocks
+
+> Go to [documentation](https://zensical.org/docs/authoring/code-blocks/)
+
+``` python hl_lines="2" title="Code blocks"
+def greet(name):
+    print(f"Hello, {name}!") # (1)!
+
+greet("Python")
+```
+
+1.  > Go to [documentation](https://zensical.org/docs/authoring/code-blocks/#code-annotations)
+
+    Code annotations allow to attach notes to lines of code.
+
+Code can also be highlighted inline: `#!python print("Hello, Python!")`.
+
+## Content tabs
+
+> Go to [documentation](https://zensical.org/docs/authoring/content-tabs/)
+
+=== "Python"
+
+    ``` python
+    print("Hello from Python!")
+    ```
+
+=== "Rust"
+
+    ``` rs
+    println!("Hello from Rust!");
+    ```
+
+## Diagrams
+
+> Go to [documentation](https://zensical.org/docs/authoring/diagrams/)
+
+``` mermaid
+graph LR
+  A[Start] --> B{Error?};
+  B -->|Yes| C[Hmm...];
+  C --> D[Debug];
+  D --> B;
+  B ---->|No| E[Yay!];
+```
+
+## Footnotes
+
+> Go to [documentation](https://zensical.org/docs/authoring/footnotes/)
+
+Here's a sentence with a footnote.[^1]
+
+Hover it, to see a tooltip.
+
+[^1]: This is the footnote.
+
+
+## Formatting
+
+> Go to [documentation](https://zensical.org/docs/authoring/formatting/)
+
+- ==This was marked (highlight)==
+- ^^This was inserted (underline)^^
+- ~~This was deleted (strikethrough)~~
+- H~2~O
+- A^T^A
+- ++ctrl+alt+del++
+
+## Icons, Emojis
+
+> Go to [documentation](https://zensical.org/docs/authoring/icons-emojis/)
+
+* :sparkles: `:sparkles:`
+* :rocket: `:rocket:`
+* :tada: `:tada:`
+* :memo: `:memo:`
+* :eyes: `:eyes:`
+
+## Maths
+
+> Go to [documentation](https://zensical.org/docs/authoring/math/)
+
+$$
+\cos x=\sum_{k=0}^{\infty}\frac{(-1)^k}{(2k)!}x^{2k}
+$$
+
+!!! warning "Needs configuration"
+    Note that MathJax is included via a `script` tag on this page and is not
+    configured in the generated default configuration to avoid including it
+    in a pages that do not need it. See the documentation for details on how
+    to configure it on all your pages if they are more Maths-heavy than these
+    simple starter pages.
+
+<script id="MathJax-script" src="https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js"></script>
+<script>
+  window.MathJax = {
+    tex: {
+      inlineMath: [["\\(", "\\)"]],
+      displayMath: [["\\[", "\\]"]],
+      processEscapes: true,
+      processEnvironments: true
+    },
+    options: {
+      ignoreHtmlClass: ".*|",
+      processHtmlClass: "arithmatex"
+    }
+  };
+
+  document$.subscribe(() => {
+    MathJax.startup.output.clearCache()
+    MathJax.typesetClear()
+    MathJax.texReset()
+    MathJax.typesetPromise()
+  })
+</script>
+
+## Task Lists
+
+> Go to [documentation](https://zensical.org/docs/authoring/lists/#using-task-lists)
+
+* [x] Install Zensical
+* [x] Configure `zensical.toml`
+* [x] Write amazing documentation
+* [ ] Deploy anywhere
+
+## Tooltips
+
+> Go to [documentation](https://zensical.org/docs/authoring/tooltips/)
+
+[Hover me][example]
+
+  [example]: https://example.com "I'm a tooltip!"

--- a/docs/lcd_ob.md
+++ b/docs/lcd_ob.md
@@ -1,0 +1,46 @@
+---
+icon: lucide/cloud-sun
+---
+
+# NOAA Local Climatological Data (LCD)
+
+Downloads and cleans hourly station weather observations (temperature, precipitation, wind, relative humidity, sky cover) from NOAA's [Local Climatological Data](https://www.ncei.noaa.gov/access/services/support/v3/datasets.json) (LCD) API, e.g. from the Burlington International Airport station. The raw API response requires substantial cleanup — duplicate report handling, suspect/missing value markers, trace-precipitation encoding — which this module handles internally.
+
+## `get_data()`
+
+Downloads and processes LCD data, returning a nested dictionary of Pandas Series for each variable, for each location.
+
+**Parameters:**
+
+- `start_date` — the start date for which to grab data.
+- `end_date` — the end date for which to grab data.
+- `locations` — a dictionary of location name to LCD station ID.
+- `variables` — a dictionary of variables to download; keys are user-defined names, values are LCD field names. Only the fields in `standard_var_units`/`metric_var_units` (`HourlySkyConditions`, `HourlyPrecipitation`, `HourlyDryBulbTemperature`, `HourlyRelativeHumidity`, `HourlyWindSpeed`, `HourlyWindDirection`) have been tested.
+- `units` — unit system for the request: `'standard'` (US units, default) or `'metric'`.
+
+**Returns:**
+
+- A nested dict where 1st-level keys are user-provided location names and 2nd-level keys are variable names, with values as Pandas Series named `"{user_name} ({units})"`.
+
+## `lcdRequest()`
+
+Sends the raw request to the NOAA LCD API for a single station, variable list, date range, and unit system, retrying until a valid JSON response is received.
+
+**Parameters:**
+
+- `startDate` / `endDate` — request date range (time-of-day is ignored; the request always covers full UTC days).
+- `var_list` — LCD-specific variable names to request.
+- `station_id` — LCD station ID.
+- `units` — `'standard'` or `'metric'`.
+
+**Returns:**
+
+- A Pandas DataFrame of the raw API response, one row per report.
+
+??? info "Internal cleaning helpers"
+    These handle the LCD API's quirks and are not intended to be called directly:
+
+    - `clean_raw_df()` — deduplicates report timestamps (preferring `FM-16` > `FM-15` > `FM-12` > `SOD` reports) and indexes by UTC time.
+    - `scrubSpecialChars()` — strips `'s'` (suspect) and `'*'` (missing) indicator characters and casts to float.
+    - `process_clouds()` / `splitsky()` / `sky2prop()` — parse raw sky-condition strings (e.g. `'SCT:04 015'`) into a fractional sky-cover value.
+    - `process_rain()` / `leavenotrace()` — convert trace ("T") precipitation readings to 0.00 and flag malformed values as NaN. `process_rain()` is not currently called by `get_data()`, which handles precipitation cleanup inline via `leavenotrace()` directly.

--- a/docs/markdown.md
+++ b/docs/markdown.md
@@ -1,0 +1,111 @@
+---
+icon: simple/markdown
+---
+
+# Markdown in 5min
+
+## Headers
+
+```
+# H1 Header
+## H2 Header
+### H3 Header
+#### H4 Header
+##### H5 Header
+###### H6 Header
+```
+
+## Text formatting
+
+```
+**bold text**
+*italic text*
+***bold and italic***
+~~strikethrough~~
+`inline code`
+```
+
+## Links and images
+
+```
+[Link text](https://example.com)
+[Link with title](https://example.com "Hover title")
+![Alt text](image.jpg)
+![Image with title](image.jpg "Image title")
+```
+
+## Lists
+
+```
+Unordered:
+
+- Item 1
+- Item 2
+  - Nested item
+
+Ordered:
+
+1. First item
+2. Second item
+3. Third item
+```
+
+## Blockquotes
+
+```
+> This is a blockquote
+> Multiple lines
+>> Nested quote
+```
+
+## Code blocks
+
+````
+```javascript
+function hello() {
+  console.log("Hello, world!");
+}
+```
+````
+
+## Tables
+
+```
+| Header 1 | Header 2 | Header 3 |
+|----------|----------|----------|
+| Row 1    | Data     | Data     |
+| Row 2    | Data     | Data     |
+```
+
+## Horizontal rule
+
+```
+---
+or
+***
+or
+___
+```
+
+## Task lists
+
+```
+- [x] Completed task
+- [ ] Incomplete task
+- [ ] Another task
+```
+
+## Escaping characters
+
+```
+Use backslash to escape: \* \_ \# \`
+```
+
+## Line breaks
+
+```
+End a line with two spaces  
+to create a line break.
+
+Or use a blank line for a new paragraph.
+```

--- a/docs/nwm_fc.md
+++ b/docs/nwm_fc.md
@@ -1,0 +1,47 @@
+---
+icon: lucide/droplet
+---
+
+# National Water Model Acquisition Module
+
+Downloads and processes National Water Model (NWM) streamflow forecast data from either [Google Cloud Storage](https://console.cloud.google.com/storage/browser/national-water-model) (GCS, holds NWM data back to 2018) or [NOMADS](https://nomads.ncep.noaa.gov/pub/data/nccf/com/nwm/prod/) (holds only the last 2 days' runs). Supports any forecast member (`medium_range_mem1`, `long_range_mem3`, `short_range`, `analysis_assim`, etc.) at any model cycle, but only downloads `channel_rt` files, which contain `streamflow`, `velocity`, and `nudge` variables — `land` and `reservoir` files are not currently supported.
+
+## `get_data()`
+
+Downloads and processes NWM hydrology forecast data, returning a nested dictionary of Pandas Series for each variable, for each location.
+
+**Parameters:**
+
+- `start_date` / `end_date` — the date range to retrieve data for.
+- `member` — the NWM forecast member to get (e.g. `medium_range_mem1`, `long_range_mem3`, `short_range`, `analysis_assim`).
+- `locations` — a dictionary mapping location name to reach/gauge ID (`feature_id`).
+- `variables` — a dictionary mapping user-defined variable names to `channel_rt` variable names (`streamflow`, `velocity`, `nudge`).
+- `reference_date` — the forecast reference time (launch date/cycle). Defaults to `start_date` if `None`. For `analysis_assim`, this is required and represents the corresponding short-range forecast launch time.
+- `data_dir` — directory to store downloaded data. Defaults to the OS temp directory.
+- `format` — `'dictionary'` (default) for a nested Series dict, or `'xarray'` for an `xr.Dataset`.
+- `gcs` — whether to use the GCS bucket (`True`, default) instead of NOMADS.
+- `end_date_exclusive` — whether to exclude `end_date` from the returned series. Defaults to `True`.
+- `dwnld_threads` / `load_threads` — thread counts for downloading and reading data, respectively.
+
+**Returns:**
+
+- A nested dict where 1st-level keys are user-provided location names and 2nd-level keys are variable names, with values as Pandas Series — or an `xr.Dataset` if `format='xarray'`.
+
+## `download_nwm()`
+
+Downloads the `channel_rt` NetCDF files for a single forecast product (member + reference date) from GCS or NOMADS.
+
+**Parameters:** `reference_date`, `member`, `hours` (`'all'`, an int, or a list of ints), `gcs`, `download_dir`, `num_threads`.
+
+**Returns:** a list of downloaded file paths.
+
+## `process_nwm()`
+
+Loads and slices NWM forecast NetCDF files by time, location, and variable, returning the result in the requested format.
+
+**Parameters:** `start_ts`, `end_ts`, `locations`, `variables`, `nwm_data_dir`, `fname_template`, `format`, `end_date_exclusive`, `num_threads`.
+
+**Returns:** a nested dict of Pandas Series, or an `xr.Dataset`, matching `get_data()`'s return convention.
+
+??? info "Internal helpers"
+    - `prepForDownloads()` — parses the reference date and builds the file name template and local directory structure for a given member.

--- a/docs/nwm_forcings_fc.md
+++ b/docs/nwm_forcings_fc.md
@@ -1,0 +1,50 @@
+---
+icon: lucide/cloud-rain
+---
+
+# National Water Model Forecast Forcings
+
+Downloads and processes the meteorological forcing inputs (precipitation rate, air temperature, wind, humidity, pressure, radiation — see `NWM_FORCING_VARS`) used to drive NWM `medium_range` and `short_range` forecasts, from the [NWM Google Cloud Storage bucket](https://console.cloud.google.com/storage/browser/national-water-model). Unlike most acquisition modules, this one supports two output shapes: spatial subsetting by bounding box (returns a gridded `xr.Dataset`) or by a set of named points (returns the usual nested dict of Pandas Series).
+
+## `get_data()`
+
+Downloads and processes NWM forecast forcings data.
+
+**Parameters:**
+
+- `start_date` / `end_date` — the date range to retrieve data for.
+- `member` — the NWM forecast member to get forcings for (`'medium_range'`, `'short_range'`, `'analysis_assim'`, `'analysis_assim_extend'`).
+- `locations` — `None` (no spatial subsetting), `{'bbox': {'min_lat':..., 'max_lat':..., 'min_lon':..., 'max_lon':...}}`, or `{'points': {name: (lat, lon), ...}}`. See `validate_locations()`.
+- `variables` — a dict/list of variables to extract, or `'all'` (default) to keep every forcing variable.
+- `reference_date` — the forecast reference time. Defaults to `start_date` if `None`.
+- `data_dir` — directory to store downloaded data. Defaults to the OS temp directory.
+- `end_date_exclusive` — whether to exclude `end_date` from the returned series. Defaults to `True`.
+- `dwnld_threads` — number of threads for downloading. Defaults to half the available CPU cores.
+
+**Returns:**
+
+- If `locations` is `None` or a bounding box: an `xr.Dataset` covering the requested area/variables. If `locations` specifies points: a nested dict where 1st-level keys are point names and 2nd-level keys are variable names, with values as Pandas Series.
+
+## `download_nwm_forcings()`
+
+Downloads the forcing NetCDF files for a given forecast member, reference date, and set of forecast hours from the GCS bucket.
+
+**Parameters:** `reference_date`, `member`, `hours`, `download_dir`, `num_threads`.
+
+**Returns:** a list of downloaded file paths.
+
+## `process_nwm_forcings()`
+
+Loads the downloaded forcing files, applies variable/location subsetting during load (via `preprocess_forcings_datasets()` as an `xarray.open_mfdataset` preprocessor for efficiency), localizes timestamps to UTC, and — for point subsetting — converts the result into a nested Series dictionary.
+
+**Parameters:** `start_ts`, `end_ts`, `nwm_date_dir`, `member`, `reference_date`, `locations`, `variables`, `end_date_exclusive`.
+
+**Returns:** an `xr.Dataset` or nested dict, matching `get_data()`'s return convention.
+
+??? info "Internal helpers"
+    - `prepForDownloads()` — builds the file name template and local directory structure for a given member/reference date.
+    - `subset_by_bbox()` / `subset_by_points()` — perform the actual bounding-box clip (via `rioxarray`) or nearest-point selection (via a CRS transform into the forcing grid's projection).
+    - `validate_locations()` — validates the `locations` argument and determines which subsetting method (`'bbox'`, `'points'`, or `None`) applies.
+    - `parse_variables()` — normalizes the `variables` argument (list, dict, or `'all'`) into a `{user_name: dataset_name}` dict.
+    - `preprocess_forcings_datasets()` — per-file preprocessing hook applying variable and location subsetting before concatenation.
+    - `estimate_chunk_sizes_auto()` — estimates dask chunk sizes for loading based on available system memory.

--- a/docs/nwmretro_forcings3_ob.md
+++ b/docs/nwmretro_forcings3_ob.md
@@ -1,0 +1,25 @@
+---
+icon: lucide/cloud-rain
+---
+
+# NWM v3.0 Retrospective Forcings
+
+Downloads the meteorological forcing inputs (precipitation rate, 2-m air temperature) used to drive version 3.0 of the National Water Model's retrospective run, reading directly from the [public v3.0 retrospective Zarr store on AWS](https://noaa-nwm-retrospective-3-0-pds.s3.amazonaws.com/index.html#CONUS/zarr/forcing/). Each requested lat/lon location is reprojected into the forcing grid's Lambert Conformal Conic coordinates and matched to the nearest grid cell.
+
+## `get_data()`
+
+Downloads and processes NWM v3.0 retrospective forcings data, returning a nested dictionary of Pandas Series for each variable, for each location.
+
+**Parameters:**
+
+- `start_date` — the start date for which to grab data.
+- `end_date` — the end date for which to grab data.
+- `locations` — a dictionary mapping location name to a `(lat, lon)` coordinate tuple.
+- `variables` — a dictionary mapping user-defined variable names to dataset variable names. Supported values are `'RAINRATE'` (precipitation rate) and `'T2D'` (2-m air temperature).
+
+**Returns:**
+
+- A nested dict where 1st-level keys are user-provided location names and 2nd-level keys are variable names, with values as Pandas Series (end-date exclusive).
+
+!!! note "Related module"
+    For the older NWM v2.1 retrospective forcings, see [`nwmretro_forcings_ob`](nwmretro_forcings_ob.md).

--- a/docs/nwmretro_forcings_ob.md
+++ b/docs/nwmretro_forcings_ob.md
@@ -1,0 +1,25 @@
+---
+icon: lucide/cloud-rain
+---
+
+# NWM v2.1 Retrospective Forcings
+
+Downloads the meteorological forcing inputs (LDASIN files) used to drive version 2.1 of the National Water Model's retrospective run, from the [CIROH-hosted Zarr mirror on AWS](https://ciroh-nwm-zarr-retrospective-data-copy.s3.amazonaws.com/index.html). Unlike the v3.0 store, the v2.1 archive is exposed as per-timestep JSON references rather than a native Zarr dataset, so this module uses `kerchunk`'s `MultiZarrToZarr` to build a virtual, concatenated Zarr dataset on the fly. The dataset's native Lambert Conformal Conic grid is reprojected to lat/lon in order to locate each requested point.
+
+## `get_data()`
+
+Downloads and processes NWM v2.1 retrospective forcings data, returning a nested dictionary of Pandas Series for each variable, for each location.
+
+**Parameters:**
+
+- `start_date` — the start date for which to grab data.
+- `end_date` — the end date for which to grab data.
+- `locations` — a dictionary mapping location name to a `(lat, lon)` coordinate tuple.
+- `variables` — a dictionary mapping user-defined variable names to dataset variable names, drawn from the LDASIN forcing fields.
+
+**Returns:**
+
+- A nested dict where 1st-level keys are user-provided location names and 2nd-level keys are variable names, with values as Pandas Series.
+
+!!! note "Related module"
+    For the newer, natively-Zarr NWM v3.0 retrospective forcings, see [`nwmretro_forcings3_ob`](nwmretro_forcings3_ob.md) — prefer that module unless v2.1-specific data is required.

--- a/docs/nwmv3_retro_fc.md
+++ b/docs/nwmv3_retro_fc.md
@@ -1,0 +1,21 @@
+---
+icon: lucide/droplet
+---
+
+# NWM v3.0 Retrospective Streamflow
+
+Downloads channel-routing output (CHRTOUT variables — streamflow, velocity, lateral/bucket runoff) from version 3.0 of the National Water Model's single long-term [retrospective run](https://registry.opendata.aws/nwm-archive/), reading directly from the public Zarr store on AWS. Unlike the operational forecast products, NWM retrospective runs are produced only once per model version, so there is no forecast cycle or reference date to specify.
+
+## `get_data()`
+
+Downloads and processes NWM v3.0 retrospective CHRTOUT data, returning a nested dictionary of Pandas Series for each variable, for each location.
+
+**Parameters:**
+
+- `start_date` / `end_date` — the date range to retrieve data for.
+- `locations` — a dictionary mapping reach name to NWM `feature_id` (reach ID).
+- `variables` — a dictionary mapping user-defined variable names to CHRTOUT variable names. Defaults to `{'streamflow':'streamflow'}`. Other available variables include `qBtmVertRunoff`, `qBucket`, `qSfcLatRunoff`, `q_lateral`, and `velocity`.
+
+**Returns:**
+
+- A nested dict where 1st-level keys are user-provided reach names and 2nd-level keys are variable names, with values as Pandas Series named `"{var} ({unit})"`. Series are end-date exclusive.

--- a/docs/sentinel3_ob.md
+++ b/docs/sentinel3_ob.md
@@ -1,0 +1,54 @@
+---
+icon: lucide/satellite
+---
+
+# Sentinel-3 Cyanobacteria Index (CI) Imagery
+
+Downloads and processes Sentinel-3 OLCI Cyanobacterial Index (CI) satellite tiles from NASA's [Ocean Color CyAN](https://oceancolor.gsfc.nasa.gov/about/projects/cyan/) portal for a given area/tile ID, producing a time-stacked xarray Dataset of Digital Number (DN) rasters. Unlike the other acquisition modules, this one returns gridded imagery rather than a per-location Series dictionary, and its pipeline (download → reproject to WGS84 → crop to an area of interest → optional DN→CI conversion) is implemented as a stateful class, `CIFilesDownloadProcess`, which `get_data()` orchestrates.
+
+## `get_data()`
+
+Runs the full CI tile pipeline for a date range and area, returning the resulting raster time series.
+
+**Parameters:**
+
+- `start_date` / `end_date` — the date range to download CI tiles for.
+- `appkey` — NASA Ocean Color app key for authentication (see the [CyAN docs](https://oceancolor.gsfc.nasa.gov/about/projects/cyan/) for how to obtain one).
+- `cropbox` — `(lat, lon, lat, lon)` corners defining the area to crop each GeoTIFF to.
+- `output_dir` — directory where output files (and intermediate temp files) are stored.
+- `areaid` — string designating the tile/area ID to download, e.g. `"8_2"` for the Champlain Valley. Defaults to `"8_2"`.
+- `convert_to_ci` — whether to convert Digital Number values to Cyanobacterial Index values in addition to returning the raw DN rasters. Defaults to `False` — as of 2025-07-30 this conversion has produced problematic results and is not currently recommended.
+- `remove_temp` — whether to delete intermediate temp files after processing. Defaults to `True`.
+
+**Returns:**
+
+- An xarray Dataset with a `DN` variable stacked along a `time` dimension (one slice per downloaded tile), in the `EPSG:4326` (WGS84) CRS.
+
+!!! note "Unused parameters"
+    `locations`, `variables`, and `service` are accepted but not currently used by `get_data()` — the area downloaded is controlled entirely by `areaid` and `cropbox`.
+
+??? info "Internal pipeline (`CIFilesDownloadProcess`)"
+    `get_data()` instantiates this class and calls its methods in sequence; they are not intended to be used standalone:
+
+    - `download_urls()` — queries the CyAN file-search API for tile URLs matching the date range and area, saving them to a text file.
+    - `download_tiles()` — invokes `data/ci_data_download/ci-download.py` as a subprocess to download the listed tiles.
+    - `convert_projection()` / `reproject_to_wgs84()` — reprojects downloaded GeoTIFFs to `EPSG:4326`.
+    - `crop_aoi()` / `crop_using_gdal()` — crops reprojected tiles to `cropbox`.
+    - `convert_dn_to_ci()` / `dn_to_ci()` — optional DN→CI conversion.
+    - `remove_temp_dir()` — cleans up intermediate files.
+    - `tif_to_ds()` — loads the cropped GeoTIFFs into a single time-stacked xarray Dataset.
+
+## `plot()`
+
+Plots a single time slice (2D array) of Sentinel-3 DN data, with an optional basemap.
+
+**Parameters:**
+
+- `da` — a 2D DN DataArray (a single time slice) to plot.
+- `cmap` — colormap to use. If omitted, a custom colormap is built where DN value 254 (ground) renders white and 255 (no-data/cloud) renders black.
+- `base` — whether to overlay a basemap using the DataArray's CRS. Defaults to `True`.
+- `title` — plot title. If omitted, no title is set.
+
+**Returns:**
+
+- The matplotlib `Axes` object for the plot.

--- a/docs/usgs_ob.md
+++ b/docs/usgs_ob.md
@@ -1,0 +1,38 @@
+---
+icon: lucide/droplet
+---
+
+# USGS Streamflow Observations
+
+Downloads observed streamflow, gage height, and related hydrology data from the [USGS NWIS web services](https://waterservices.usgs.gov/docs/), supporting both instantaneous and daily-values services.
+
+## `get_data()`
+
+Downloads and processes USGS observational hydrology data, returning a nested dictionary of Pandas Series for each variable, for each location.
+
+**Parameters:**
+
+- `start_date` — the start date for which to grab data.
+- `end_date` — the end date for which to grab data.
+- `locations` — a dictionary mapping station name to USGS site ID.
+- `variables` — a dictionary mapping user-defined variable names to [USGS parameter codes](https://help.waterdata.usgs.gov/parameter_cd?group_cd=PHY) (e.g. `'00060'` for mean daily streamflow, `'00061'` for instantaneous streamflow, `'00065'` for gage height). Defaults to `{'streamflow':'00060'}`.
+- `service` — which USGS service to use: `'iv'` (instantaneous values, default) or `'dv'` (daily values). See the [USGS docs](https://waterservices.usgs.gov/docs/) for other options.
+
+**Returns:**
+
+- A nested dict where 1st-level keys are user-provided station names and 2nd-level keys are variable names, with values as Pandas Series named `"{var} ({unit})"`.
+
+## `USGSgetvars_function()`
+
+Builds the USGS NWIS request URL for a single station and set of variables, and returns the parsed response. Retries on failure.
+
+**Parameters:**
+
+- `id` — USGS site ID.
+- `variables` — a dictionary mapping user-defined variable names to USGS parameter codes.
+- `start` / `end` — start and end datetimes for the request.
+- `service` — `'iv'` or `'dv'`.
+
+**Returns:**
+
+- A dictionary mapping variable name to a Pandas Series of that variable's data, indexed by timestamp.

--- a/models/aem3d/AEM3DSheet.py
+++ b/models/aem3d/AEM3DSheet.py
@@ -188,7 +188,7 @@ class AEM3DSheet:
 		else:
 			daslice.plot(ax=axs, **kwargs)
 		if (base):
-			cx.add_basemap(axs, crs=targetcrs)
+			cx.add_basemap(axs, crs=targetcrs, url=cx.providers.OpenStreetMap.Mapnik)
 		
 		plt.title(title)
 		return(axs)

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,0 +1,351 @@
+# ============================================================================
+#
+# The configuration produced by default is meant to highlight the features
+# that Zensical provides and to serve as a starting point for your own
+# projects.
+#
+# ============================================================================
+
+[project]
+
+# The site_name is shown in the page header and the browser window title
+#
+# Read more: https://zensical.org/docs/setup/basics/#site_name
+site_name = "Forecast Workflow Documentation"
+
+# The site_description is included in the HTML head and should contain a
+# meaningful description of the site content for use by search engines.
+#
+# Read more: https://zensical.org/docs/setup/basics/#site_description
+site_description = "A new project generated from the default template project."
+
+# The site_author attribute. This is used in the HTML head element.
+#
+# Read more: https://zensical.org/docs/setup/basics/#site_author
+site_author = "Noah Beckage"
+
+# The site_url is the canonical URL for your site. When building online
+# documentation you should set this.
+# Read more: https://zensical.org/docs/setup/basics/#site_url
+#site_url = "https://ciroh-uvm.github.io/forecast-workflow/"
+
+# The copyright notice appears in the page footer and can contain an HTML
+# fragment.
+#
+# Read more: https://zensical.org/docs/setup/basics/#copyright
+copyright = """
+Copyright &copy; 2026 The authors
+"""
+
+# Zensical supports both implicit navigation and explicitly defined navigation.
+# If you decide not to define a navigation here then Zensical will simply
+# derive the navigation structure from the directory structure of your
+# "docs_dir". The definition below demonstrates how a navigation structure
+# can be defined using TOML syntax.
+#
+# Read more: https://zensical.org/docs/setup/navigation/
+nav = [
+  { "Get started" = "index.md" },
+  { "Markdown in 5min" = "markdown.md" },
+  { "Observations" = ["aorc_ob.md", "caflow_ob.md", "femc_ob.md", "lcd_ob.md", "nwmretro_forcings_ob.md", "nwmretro_forcings3_ob.md", "sentinel3_ob.md", "usgs_ob.md"] },
+  { "Forecasts" = ["cfs_fc.md", "gfs_fc.md", "gfs_fc_thredds.md", "nwm_fc.md", "nwm_forcings_fc.md", "nwmv3_retro_fc.md"] },
+]
+
+# With the "extra_css" option you can add your own CSS styling to customize
+# your Zensical project according to your needs. You can add any number of
+# CSS files.
+#
+# The path provided should be relative to the "docs_dir".
+#
+# Read more: https://zensical.org/docs/customization/#additional-css
+#
+#extra_css = ["stylesheets/extra.css"]
+
+# With the `extra_javascript` option you can add your own JavaScript to your
+# project to customize the behavior according to your needs.
+#
+# The path provided should be relative to the "docs_dir".
+#
+# Read more: https://zensical.org/docs/customization/#additional-javascript
+#extra_javascript = ["javascripts/extra.js"]
+
+# ----------------------------------------------------------------------------
+# Section for configuring theme options
+# ----------------------------------------------------------------------------
+[project.theme]
+
+# change this to "classic" to use the traditional Material for MkDocs look.
+#variant = "classic"
+
+# Zensical allows you to override specific blocks, partials, or whole
+# templates as well as to define your own templates. To do this, uncomment
+# the custom_dir setting below and set it to a directory in which you
+# keep your template overrides.
+#
+# Read more:
+# - https://zensical.org/docs/customization/#extending-the-theme
+#
+#custom_dir = "overrides"
+
+# With the "favicon" option you can set your own image to use as the icon
+# browsers will use in the browser title bar or tab bar. The path provided
+# must be relative to the "docs_dir".
+#
+# Read more:
+# - https://zensical.org/docs/setup/logo-and-icons/#favicon
+# - https://developer.mozilla.org/en-US/docs/Glossary/Favicon
+#
+#favicon = "images/favicon.png"
+
+# Zensical supports more than 60 different languages. This means that the
+# labels and tooltips that Zensical's templates produce are translated.
+# The "language" option allows you to set the language used. This language
+# is also indicated in the HTML head element to help with accessibility
+# and guide search engines and translation tools.
+#
+# The default language is "en" (English). It is possible to create
+# sites with multiple languages and configure a language selector. See
+# the documentation for details.
+#
+# Read more:
+# - https://zensical.org/docs/setup/language/
+#
+language = "en"
+
+# Zensical provides a number of feature toggles that change the behavior
+# of the documentation site.
+features = [
+    # Zensical includes an announcement bar. This feature allows users to
+    # dismiss it when they have read the announcement.
+    # https://zensical.org/docs/setup/header/#announcement-bar
+    "announce.dismiss",
+
+    # If you have a repository configured and turn on this feature, Zensical
+    # will generate an edit button for the page. This works for common
+    # repository hosting services.
+    # https://zensical.org/docs/setup/repository/#content-actions
+    #"content.action.edit",
+
+    # If you have a repository configured and turn on this feature, Zensical
+    # will generate a button that allows the user to view the Markdown
+    # code for the current page.
+    # https://zensical.org/docs/setup/repository/#content-actions
+    #"content.action.view",
+
+    # Code annotations allow you to add an icon with a tooltip to your
+    # code blocks to provide explanations at crucial points.
+    # https://zensical.org/docs/authoring/code-blocks/#code-annotations
+    "content.code.annotate",
+
+    # This feature turns on a button in code blocks that allow users to
+    # copy the content to their clipboard without first selecting it.
+    # https://zensical.org/docs/authoring/code-blocks/#code-copy-button
+    "content.code.copy",
+
+    # Code blocks can include a button to allow for the selection of line
+    # ranges by the user.
+    # https://zensical.org/docs/authoring/code-blocks/#code-selection-button
+    "content.code.select",
+
+    # Zensical can render footnotes as inline tooltips, so the user can read
+    # the footnote without leaving the context of the document.
+    # https://zensical.org/docs/authoring/footnotes/#footnote-tooltips
+    "content.footnote.tooltips",
+
+    # If you have many content tabs that have the same titles (e.g., "Python",
+    # "JavaScript", "Cobol"), this feature causes all of them to switch to
+    # at the same time when the user chooses their language in one.
+    # https://zensical.org/docs/authoring/content-tabs/#linked-content-tabs
+    "content.tabs.link",
+
+    # With this feature enabled users can add tooltips to links that will be
+    # displayed when the mouse pointer hovers the link.
+    # https://zensical.org/docs/authoring/tooltips/#improved-tooltips
+    "content.tooltips",
+
+    # With this feature enabled, Zensical will automatically hide parts
+    # of the header when the user scrolls past a certain point.
+    # https://zensical.org/docs/setup/header/#automatic-hiding
+    # "header.autohide",
+
+    # Turn on this feature to expand all collapsible sections in the
+    # navigation sidebar by default.
+    # https://zensical.org/docs/setup/navigation/#navigation-expansion
+    # "navigation.expand",
+
+    # This feature turns on navigation elements in the footer that allow the
+    # user to navigate to a next or previous page.
+    # https://zensical.org/docs/setup/footer/#navigation
+    "navigation.footer",
+
+    # When section index pages are enabled, documents can be directly attached
+    # to sections, which is particularly useful for providing overview pages.
+    # https://zensical.org/docs/setup/navigation/#section-index-pages
+    "navigation.indexes",
+
+    # When instant navigation is enabled, clicks on all internal links will be
+    # intercepted and dispatched via XHR without fully reloading the page.
+    # https://zensical.org/docs/setup/navigation/#instant-navigation
+    "navigation.instant",
+
+    # With instant prefetching, your site will start to fetch a page once the
+    # user hovers over a link. This will reduce the perceived loading time
+    # for the user.
+    # https://zensical.org/docs/setup/navigation/#instant-prefetching
+    "navigation.instant.prefetch",
+
+    # In order to provide a better user experience on slow connections when
+    # using instant navigation, a progress indicator can be enabled.
+    # https://zensical.org/docs/setup/navigation/#progress-indicator
+    #"navigation.instant.progress",
+
+    # When navigation paths are activated, a breadcrumb navigation is rendered
+    # above the title of each page
+    # https://zensical.org/docs/setup/navigation/#navigation-path
+    "navigation.path",
+
+    # When pruning is enabled, only the visible navigation items are included
+    # in the rendered HTML, reducing the size of the built site by 33% or more.
+    # https://zensical.org/docs/setup/navigation/#navigation-pruning
+    #"navigation.prune",
+
+    # When sections are enabled, top-level sections are rendered as groups in
+    # the sidebar for viewports above 1220px, but remain as-is on mobile.
+    # https://zensical.org/docs/setup/navigation/#navigation-sections
+    "navigation.sections",
+
+    # When tabs are enabled, top-level sections are rendered in a menu layer
+    # below the header for viewports above 1220px, but remain as-is on mobile.
+    # https://zensical.org/docs/setup/navigation/#navigation-tabs
+    #"navigation.tabs",
+
+    # When sticky tabs are enabled, navigation tabs will lock below the header
+    # and always remain visible when scrolling down.
+    # https://zensical.org/docs/setup/navigation/#sticky-navigation-tabs
+    #"navigation.tabs.sticky",
+
+    # A back-to-top button can be shown when the user, after scrolling down,
+    # starts to scroll up again.
+    # https://zensical.org/docs/setup/navigation/#back-to-top-button
+    "navigation.top",
+
+    # When anchor tracking is enabled, the URL in the address bar is
+    # automatically updated with the active anchor as highlighted in the table
+    # of contents.
+    # https://zensical.org/docs/setup/navigation/#anchor-tracking
+    "navigation.tracking",
+
+    # When search highlighting is enabled and a user clicks on a search result,
+    # Zensical will highlight all occurrences after following the link.
+    # https://zensical.org/docs/setup/search/#search-highlighting
+    "search.highlight",
+
+    # When anchor following for the table of contents is enabled, the sidebar
+    # is automatically scrolled so that the active anchor is always visible.
+    # https://zensical.org/docs/setup/navigation/#anchor-following
+    # "toc.follow",
+
+    # When navigation integration for the table of contents is enabled, it is
+    # always rendered as part of the navigation sidebar on the left.
+    # https://zensical.org/docs/setup/navigation/#navigation-integration
+    #"toc.integrate",
+]
+
+# ----------------------------------------------------------------------------
+# You can configure your own logo to be shown in the header using the "logo"
+# option in the "theme" subsection. The logo must be a relative path to a file
+# in your "docs_dir", e.g., to use `docs/assets/logo.png` you would set:
+# ----------------------------------------------------------------------------
+#logo = "assets/logo.png"
+
+# ----------------------------------------------------------------------------
+# If you don't have a dedicated project logo, you can use a built-in icon from
+# the icon sets shipped in Zensical. Please note that the setting lives in a
+# different subsection, and that the above take precedence over the icon.
+#
+# Read more:
+# - https://zensical.org/docs/setup/logo-and-icons
+# - https://github.com/zensical/ui/tree/master/dist/.icons
+# ----------------------------------------------------------------------------
+#[project.theme.icon]
+#logo = "lucide/smile"
+
+# ----------------------------------------------------------------------------
+# In the "font" subsection you can configure the fonts used. By default, fonts
+# are loaded from Google Fonts, giving you a wide range of choices from a set
+# of suitably licensed fonts. There are options for a normal text font and for
+# a monospaced font used in code blocks.
+# ----------------------------------------------------------------------------
+#[project.theme.font]
+#text = "Inter"
+#code = "Jetbrains Mono"
+
+# ----------------------------------------------------------------------------
+# In the "palette" subsection you can configure options for the color scheme.
+# You can configure different color schemes, e.g., to turn on dark mode,
+# that the user can switch between. Each color scheme can be further
+# customized.
+#
+# Read more:
+# - https://zensical.org/docs/setup/colors/
+# ----------------------------------------------------------------------------
+[[project.theme.palette]]
+scheme = "default"
+toggle.icon = "lucide/sun"
+toggle.name = "Switch to dark mode"
+
+[[project.theme.palette]]
+scheme = "slate"
+toggle.icon = "lucide/moon"
+toggle.name = "Switch to light mode"
+
+# ----------------------------------------------------------------------------
+# The "extra" section contains miscellaneous settings.
+# ----------------------------------------------------------------------------
+#[[project.extra.social]]
+#icon = "fontawesome/brands/github"
+#link = "https://github.com/user/repo"
+
+# ----------------------------------------------------------------------------
+# In this section you can configure the Markdown extensions that are used when
+# rendering your documentation. We enable the most useful extensions by default,
+# but you can customize this list to your needs.
+#
+# Read more:
+# - https://zensical.org/docs/setup/extensions/
+# ----------------------------------------------------------------------------
+[project.markdown_extensions.abbr]
+[project.markdown_extensions.admonition]
+[project.markdown_extensions.attr_list]
+[project.markdown_extensions.def_list]
+[project.markdown_extensions.footnotes]
+[project.markdown_extensions.md_in_html]
+[project.markdown_extensions.toc]
+permalink = true
+[project.markdown_extensions.pymdownx.arithmatex]
+generic = true
+[project.markdown_extensions.pymdownx.betterem]
+[project.markdown_extensions.pymdownx.caret]
+[project.markdown_extensions.pymdownx.details]
+[project.markdown_extensions.pymdownx.emoji]
+emoji_generator = "zensical.extensions.emoji.to_svg"
+emoji_index = "zensical.extensions.emoji.twemoji"
+[project.markdown_extensions.pymdownx.highlight]
+anchor_linenums = true
+line_spans = "__span"
+pygments_lang_class = true
+[project.markdown_extensions.pymdownx.inlinehilite]
+[project.markdown_extensions.pymdownx.keys]
+[project.markdown_extensions.pymdownx.magiclink]
+[project.markdown_extensions.pymdownx.mark]
+[project.markdown_extensions.pymdownx.smartsymbols]
+[project.markdown_extensions.pymdownx.superfences]
+custom_fences = [
+  { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" }
+]
+[project.markdown_extensions.pymdownx.tabbed]
+alternate_style = true
+combine_header_slug = true
+[project.markdown_extensions.pymdownx.tasklist]
+custom_checkbox = true
+[project.markdown_extensions.pymdownx.tilde]


### PR DESCRIPTION
## Summary

Adds a [Zensical](https://zensical.org/) documentation website for the data-acquisition
modules under `data/`, converts those modules' docstrings to a consistent Google style,
and refreshes the README to point users to the published site.

The site can be manually deployed to https://ciroh-uvm.github.io/forecast-workflow/ via GitHub Actions.

## What's included

**Documentation site**
- One hand-written page per `data/` acquisition module (14 modules), grouped in the nav
  into **Observations** and **Forecasts** sections.
- `zensical.toml` config and a `.github/workflows/docs.yml` workflow that builds and
  publishes the site when you do so manually.
- `.gitignore` entry for the generated static `site/` directory.

**Docstrings (`data/`)**
- Converted all module docstrings to a consistent Google style (`Args:` / `Returns:` /
  `Raises:` / `Yields:`), filling in previously undocumented functions in
  `archive_fcns.py`, `sentinel3_ob.py`, `lcd_ob.py`, `caflow_ob.py`, `gfs_fc.py`, and `utils.py`.
- Fixed several docstring inaccuracies uncovered while writing the docs: phantom/incorrect
  parameters, copy-paste errors, and a corrected description of the two NWM retrospective
  forcings modules (`nwmretro_forcings_ob` = v2.1 via kerchunk; `nwmretro_forcings3_ob` = v3.0 native Zarr).

**README**
- Rewrote the landing content to explain the repo's origin (CIROH @ UVM cyanoHAB forecasting
  for Lake Champlain), summarize the reusable `data/` modules, and link to the docs site.

## Also included

Two small pre-existing fixes carried on this branch:
- `AEM3DSheet.py`: provide a reliable basemap source to the plot function.
- `utils.py`: input validation for `plot_nested_dict`.

## Notes

No behavior changes to the acquisition modules — source edits are docstrings only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)